### PR TITLE
Add prefix_path argument to buildSokol

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,21 +12,21 @@ fn macosAddSdkDirs(b: *bld.Builder, step: *bld.LibExeObjStep) !void {
 }
 
 // build sokol into a static library
-fn buildSokol(b: *bld.Builder) *bld.LibExeObjStep {
+pub fn buildSokol(b: *bld.Builder, comptime prefix_path: []const u8) *bld.LibExeObjStep {
     const lib = b.addStaticLibrary("sokol", null);
     lib.linkLibC();
     lib.setBuildMode(b.standardReleaseOptions());
+    if (prefix_path.len > 0) lib.addIncludeDir(prefix_path ++ "src/sokol/");
     if (lib.target.isDarwin()) {
         macosAddSdkDirs(b, lib) catch unreachable;
-        lib.addCSourceFile("src/sokol/sokol.c", &[_][]const u8 { "-ObjC" });
+        lib.addCSourceFile(prefix_path ++ "src/sokol/sokol.c", &[_][]const u8{"-ObjC"});
         lib.linkFramework("MetalKit");
         lib.linkFramework("Metal");
         lib.linkFramework("Cocoa");
         lib.linkFramework("QuartzCore");
         lib.linkFramework("AudioToolbox");
-    }
-    else {
-        lib.addCSourceFile("src/sokol/sokol.c", &[_][]const u8{});
+    } else {
+        lib.addCSourceFile(prefix_path ++ "src/sokol/sokol.c", &[_][]const u8{});
         if (lib.target.isLinux()) {
             lib.linkSystemLibrary("X11");
             lib.linkSystemLibrary("Xi");
@@ -49,7 +49,7 @@ fn buildExample(b: *bld.Builder, sokol: *bld.LibExeObjStep, comptime name: []con
 }
 
 pub fn build(b: *bld.Builder) void {
-    const sokol = buildSokol(b);
+    const sokol = buildSokol(b, "");
     buildExample(b, sokol, "clear");
     buildExample(b, sokol, "triangle");
     buildExample(b, sokol, "quad");


### PR DESCRIPTION
This allows another project to include sokol-zig (either directly, or as a git submodule) in its tree, but still make use of the functions defined in `build.zig`. For example, placing this repo at `./deps/sokol/`, I add to my project's `./build.zig`:

```zig
const sokol_lib = @import("deps/sokol/build.zig").buildSokol(b, "deps/sokol/");
exe.linkLibrary(sokol_lib);
exe.addPackagePath("sokol", "deps/sokol/src/sokol/sokol.zig");
```

This could be accomplished with other patterns as well, though I've seen this used naturally in a few other Zig projects.

Let me know if I should change anything, or if this is not the right approach - happy to accommodate!