### PR TITLE
Only import std once

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,6 @@
-const bld = @import("std").build;
-const mem = @import("std").mem;
+const std = @import("std");
+const bld = std.build;
+const mem = std.mem;
 
 // build sokol into a static library
 pub fn buildSokol(b: *bld.Builder, comptime prefix_path: []const u8) *bld.LibExeObjStep {


### PR DESCRIPTION
I'm not sure if that makes a difference, but that always bugged me seeing double import