### PR TITLE
build.zig: Add selection of display server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
             sudo apt-get update
-            sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev
+            sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev \
+                                 libegl-dev libwayland-dev libxkbcommon-dev
       - name: build
         run: zig build


### PR DESCRIPTION
Add compilation parameters to select enabled display servers. This
commit prepares the sokol header's wayland-support feature.

The new parameters are:
- `wayland` (false by default), and
- `x11` (true by default).

These can of course be changed, if you so desire.