### PR TITLE
Updated examples to be compatible with self-hosted

### DIFF
--- a/src/examples/blend.zig
+++ b/src/examples/blend.zig
@@ -31,7 +31,7 @@ export fn init() void {
     state.pass_action.stencil.action = .DONTCARE;
 
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32 {
+        .data = sg.asRange(&[_]f32 {
              // pos               color
             -1.0, -1.0, 0.0,  1.0, 0.0, 0.0, 0.5,
              1.0, -1.0, 0.0,  0.0, 1.0, 0.0, 0.5,
@@ -81,7 +81,7 @@ export fn frame() void {
     const bg_fs_params: shd.BgFsParams = .{ .tick = state.tick };
     sg.applyPipeline(state.bg_pip);
     sg.applyBindings(state.bind);
-    sg.applyUniforms(.FS, shd.SLOT_bg_fs_params, sg.asRange(bg_fs_params));
+    sg.applyUniforms(.FS, shd.SLOT_bg_fs_params, sg.asRange(&bg_fs_params));
     sg.draw(0, 4, 1);
 
     // draw the blended quads
@@ -106,7 +106,7 @@ export fn frame() void {
             };
             sg.applyPipeline(state.pip[src][dst]);
             sg.applyBindings(state.bind);
-            sg.applyUniforms(.VS, shd.SLOT_quad_vs_params, sg.asRange(quad_vs_params));
+            sg.applyUniforms(.VS, shd.SLOT_quad_vs_params, sg.asRange(&quad_vs_params));
             sg.draw(0, 4, 1);
             r0 += 0.6;
         }

--- a/src/examples/bufferoffsets.zig
+++ b/src/examples/bufferoffsets.zig
@@ -30,7 +30,7 @@ export fn init() void {
 
     // a 2D triangle and quad in 1 vertex buffer and 1 index buffer
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]Vertex{
+        .data = sg.asRange(&[_]Vertex{
             // triangle vertices
             .{ .x= 0.0,  .y= 0.55,  .r=1.0, .g=0.0, .b=0.0 },
             .{ .x= 0.25, .y= 0.05,  .r=0.0, .g=1.0, .b=0.0 },
@@ -45,7 +45,7 @@ export fn init() void {
     });
     state.bind.index_buffer = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{
+        .data = sg.asRange(&[_]u16{
             // triangle indices
             0, 1, 2,
             // quad indices

--- a/src/examples/bufferoffsets.zig
+++ b/src/examples/bufferoffsets.zig
@@ -15,7 +15,7 @@ const state = struct {
     var bind: sg.Bindings = .{};
 };
 
-const Vertex = packed struct {
+const Vertex = extern struct {
     x: f32, y: f32,
     r: f32, g: f32, b: f32
 };

--- a/src/examples/clear.zig
+++ b/src/examples/clear.zig
@@ -7,7 +7,6 @@ const sg    = @import("sokol").gfx;
 const sapp  = @import("sokol").app;
 const sgapp = @import("sokol").app_gfx_glue;
 const print = @import("std").debug.print;
-const builtin = @import("builtin");
 
 var pass_action: sg.PassAction = .{};
 
@@ -17,8 +16,7 @@ export fn init() void {
     });
     pass_action.colors[0] = .{ .action=.CLEAR, .value=.{ .r=1, .g=1, .b=0, .a=1 } };
 
-    const specifier = if (builtin.zig_backend == .stage1) "s" else "";
-    print("Backend: {" ++ specifier ++ "}\n", .{ sg.queryBackend()});
+    print("Backend: {}\n", .{ sg.queryBackend()});
 }
 
 export fn frame() void {

--- a/src/examples/clear.zig
+++ b/src/examples/clear.zig
@@ -7,6 +7,7 @@ const sg    = @import("sokol").gfx;
 const sapp  = @import("sokol").app;
 const sgapp = @import("sokol").app_gfx_glue;
 const print = @import("std").debug.print;
+const builtin = @import("builtin");
 
 var pass_action: sg.PassAction = .{};
 
@@ -15,7 +16,9 @@ export fn init() void {
         .context = sgapp.context()
     });
     pass_action.colors[0] = .{ .action=.CLEAR, .value=.{ .r=1, .g=1, .b=0, .a=1 } };
-    print("Backend: {s}\n", .{ sg.queryBackend()});
+
+    const specifier = if (builtin.zig_backend == .stage1) "s" else "";
+    print("Backend: {" ++ specifier ++ "}\n", .{ sg.queryBackend()});
 }
 
 export fn frame() void {

--- a/src/examples/cube.zig
+++ b/src/examples/cube.zig
@@ -26,7 +26,7 @@ export fn init() void {
 
     // cube vertex buffer
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32 {
+        .data = sg.asRange(&[_]f32 {
             // positions        colors
             -1.0, -1.0, -1.0,   1.0, 0.0, 0.0, 1.0,
              1.0, -1.0, -1.0,   1.0, 0.0, 0.0, 1.0,
@@ -63,7 +63,7 @@ export fn init() void {
     // cube index buffer
     state.bind.index_buffer = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{
+        .data = sg.asRange(&[_]u16{
             0, 1, 2,  0, 2, 3,
             6, 5, 4,  7, 6, 4,
             8, 9, 10,  8, 10, 11,
@@ -100,7 +100,7 @@ export fn frame() void {
     sg.beginDefaultPass(state.pass_action, sapp.width(), sapp.height());
     sg.applyPipeline(state.pip);
     sg.applyBindings(state.bind);
-    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(vs_params));
+    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(&vs_params));
     sg.draw(0, 36, 1);
     sg.endPass();
     sg.commit();

--- a/src/examples/debugtext-userfont.zig
+++ b/src/examples/debugtext-userfont.zig
@@ -47,7 +47,7 @@ export fn init() void {
     // characters 0x20 to 0x9F (inclusive)
     var sdtx_desc: sdtx.Desc = .{};
     sdtx_desc.fonts[UserFont] = .{
-        .data = sdtx.asRange(user_font),
+        .data = sdtx.asRange(&user_font),
         .first_char = 0x20,
         .last_char = 0x9F
     };

--- a/src/examples/instancing.zig
+++ b/src/examples/instancing.zig
@@ -38,7 +38,7 @@ export fn init() void {
     // a vertex buffer for the static particle geometry, goes into vertex buffer slot 0
     const r = 0.05;
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32{
+        .data = sg.asRange(&[_]f32{
             0.0,  -r, 0.0,   1.0, 0.0, 0.0, 1.0,
               r, 0.0, r,     0.0, 1.0, 0.0, 1.0,
               r, 0.0, -r,    0.0, 0.0, 1.0, 1.0,
@@ -51,7 +51,7 @@ export fn init() void {
     // an index buffer for the static geometry
     state.bind.index_buffer = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{
+        .data = sg.asRange(&[_]u16{
             2, 1, 0,  3, 2, 0,  4, 3, 0,  1, 4, 0,
             5, 1, 2,  5, 2, 3,  5, 3, 4,  5, 4, 1
         })
@@ -130,7 +130,7 @@ export fn frame() void {
     sg.beginDefaultPass(state.pass_action, sapp.width(), sapp.height());
     sg.applyPipeline(state.pip);
     sg.applyBindings(state.bind);
-    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(vs_params));
+    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(&vs_params));
     sg.draw(0, 24, state.cur_num_particles);
     sg.endPass();
     sg.commit();

--- a/src/examples/instancing.zig
+++ b/src/examples/instancing.zig
@@ -109,12 +109,15 @@ export fn frame() void {
     {
         var i: usize = 0;
         while (i < max_particles): (i += 1) {
-            state.vel[i].y -= 1.0 * frame_time;
-            state.pos[i] = vec3.add(state.pos[i], vec3.mul(state.vel[i], frame_time));
-            if (state.pos[i].y < -2.0) {
-                state.pos[i].y = -1.8;
-                state.vel[i].y = -state.vel[i].y;
-                state.vel[i] = vec3.mul(state.vel[i], 0.8);
+            const vel = &state.vel[i];
+            const pos = &state.pos[i];
+
+            vel.y -= 1.0 * frame_time;
+            pos.* = vec3.add(pos.*, vec3.mul(vel.*, frame_time));
+            if (pos.y < -2.0) {
+                pos.y = -1.8;
+                vel.y = -vel.y;
+                vel.* = vec3.mul(vel.*, 0.8);
             }
         }
     }

--- a/src/examples/math.zig
+++ b/src/examples/math.zig
@@ -13,7 +13,7 @@ fn radians(deg: f32) f32 {
     return deg * (math.pi / 180.0);
 }
 
-pub const Vec2 = packed struct {
+pub const Vec2 = extern struct {
     x: f32, y: f32,
 
     pub fn zero() Vec2 {
@@ -25,7 +25,7 @@ pub const Vec2 = packed struct {
     }
 };
 
-pub const Vec3 = packed struct {
+pub const Vec3 = extern struct {
     x: f32, y: f32, z: f32,
 
     pub fn zero() Vec3 {

--- a/src/examples/math.zig
+++ b/src/examples/math.zig
@@ -95,7 +95,7 @@ pub const Vec3 = packed struct {
     }
 };
 
-pub const Mat4 = packed struct {
+pub const Mat4 = extern struct {
     m: [4][4]f32,
 
     pub fn identity() Mat4 {

--- a/src/examples/mrt.zig
+++ b/src/examples/mrt.zig
@@ -65,7 +65,7 @@ export fn init() void {
 
     // create vertex buffer for a cube
     const cube_vbuf = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32{
+        .data = sg.asRange(&[_]f32{
             // positions        brightness
             -1.0, -1.0, -1.0,   1.0,
              1.0, -1.0, -1.0,   1.0,
@@ -102,7 +102,7 @@ export fn init() void {
     // index buffer for a cube
     const cube_ibuf = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{
+        .data = sg.asRange(&[_]u16{
             0, 1, 2,  0, 2, 3,
             6, 5, 4,  7, 6, 4,
             8, 9, 10,  8, 10, 11,
@@ -135,7 +135,7 @@ export fn init() void {
 
     // a vertex buffer to render a fullscreen quad
     const quad_vbuf = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32 { 0.0, 0.0,  1.0, 0.0,  0.0, 1.0,  1.0, 1.0 })
+        .data = sg.asRange(&[_]f32 { 0.0, 0.0,  1.0, 0.0,  0.0, 1.0,  1.0, 1.0 })
     });
 
     // shader and pipeline object to render a fullscreen quad which composes
@@ -185,7 +185,7 @@ export fn frame() void {
     sg.beginPass(state.offscreen.pass, state.offscreen.pass_action);
     sg.applyPipeline(state.offscreen.pip);
     sg.applyBindings(state.offscreen.bind);
-    sg.applyUniforms(.VS, shd.SLOT_offscreen_params, sg.asRange(offscreen_params));
+    sg.applyUniforms(.VS, shd.SLOT_offscreen_params, sg.asRange(&offscreen_params));
     sg.draw(0, 36, 1);
     sg.endPass();
 
@@ -194,7 +194,7 @@ export fn frame() void {
     sg.beginDefaultPass(state.default.pass_action, sapp.width(), sapp.height());
     sg.applyPipeline(state.fsq.pip);
     sg.applyBindings(state.fsq.bind);
-    sg.applyUniforms(.VS, shd.SLOT_fsq_params, sg.asRange(fsq_params));
+    sg.applyUniforms(.VS, shd.SLOT_fsq_params, sg.asRange(&fsq_params));
     sg.draw(0, 4, 1);
     sg.applyPipeline(state.dbg.pip);
     inline for (.{0, 1, 2 }) |i| {

--- a/src/examples/noninterleaved.zig
+++ b/src/examples/noninterleaved.zig
@@ -31,7 +31,7 @@ export fn init() void {
 
     // cube vertex buffer, NOTE how the vertex components are separate
     const vbuf = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32{
+        .data = sg.asRange(&[_]f32{
             // positions
             -1.0, -1.0, -1.0,   1.0, -1.0, -1.0,   1.0,  1.0, -1.0,  -1.0,  1.0, -1.0,
             -1.0, -1.0,  1.0,   1.0, -1.0,  1.0,   1.0,  1.0,  1.0,  -1.0,  1.0,  1.0,
@@ -52,7 +52,7 @@ export fn init() void {
     // cube index buffer
     const ibuf = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{
+        .data = sg.asRange(&[_]u16{
             0, 1, 2,  0, 2, 3,
             6, 5, 4,  7, 6, 4,
             8, 9, 10,  8, 10, 11,
@@ -98,7 +98,7 @@ export fn frame() void {
     sg.beginDefaultPass(.{}, sapp.width(), sapp.height());
     sg.applyPipeline(state.pip);
     sg.applyBindings(state.bind);
-    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(vs_params));
+    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(&vs_params));
     sg.draw(0, 36, 1);
     sg.endPass();
     sg.commit();

--- a/src/examples/offscreen.zig
+++ b/src/examples/offscreen.zig
@@ -69,8 +69,8 @@ export fn init() void {
     var vertices: [4000]sshape.Vertex = undefined;
     var indices: [24000]u16 = undefined;
     var buf: sshape.Buffer = .{
-        .vertices = .{ .buffer = sshape.asRange(vertices) },
-        .indices  = .{ .buffer = sshape.asRange(indices) },
+        .vertices = .{ .buffer = sshape.asRange(&vertices) },
+        .indices  = .{ .buffer = sshape.asRange(&indices) },
     };
     buf = sshape.buildTorus(buf, .{
         .radius = 0.5,
@@ -144,7 +144,7 @@ export fn frame() void {
     sg.beginPass(state.offscreen.pass, state.offscreen.pass_action);
     sg.applyPipeline(state.offscreen.pip);
     sg.applyBindings(state.offscreen.bind);
-    sg.applyUniforms(.VS, 0, sg.asRange(computeVsParams(state.rx, state.ry, 1.0, 2.5)));
+    sg.applyUniforms(.VS, 0, sg.asRange(&computeVsParams(state.rx, state.ry, 1.0, 2.5)));
     sg.draw(state.donut.base_element, state.donut.num_elements, 1);
     sg.endPass();
 
@@ -153,7 +153,7 @@ export fn frame() void {
     sg.beginDefaultPass(state.default.pass_action, sapp.width(), sapp.height());
     sg.applyPipeline(state.default.pip);
     sg.applyBindings(state.default.bind);
-    sg.applyUniforms(.VS, 0, sg.asRange(computeVsParams(-state.rx*0.25, state.ry*0.25, aspect, 2)));
+    sg.applyUniforms(.VS, 0, sg.asRange(&computeVsParams(-state.rx*0.25, state.ry*0.25, aspect, 2)));
     sg.draw(state.sphere.base_element, state.sphere.num_elements, 1);
     sg.endPass();
 

--- a/src/examples/quad.zig
+++ b/src/examples/quad.zig
@@ -21,7 +21,7 @@ export fn init() void {
 
     // a vertex buffer
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32{
+        .data = sg.asRange(&[_]f32{
             // positions      colors
             -0.5,  0.5, 0.5,  1.0, 0.0, 0.0, 1.0,
              0.5,  0.5, 0.5,  0.0, 1.0, 0.0, 1.0,
@@ -33,7 +33,7 @@ export fn init() void {
     // an index buffer
     state.bind.index_buffer = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{ 0, 1, 2, 0, 2, 3 })
+        .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3 })
     });
 
     // a shader and pipeline state object

--- a/src/examples/sgl.zig
+++ b/src/examples/sgl.zig
@@ -52,7 +52,7 @@ export fn init() void {
         .height = img_height,
     };
     // FIXME: https://github.com/ziglang/zig/issues/6068
-    img_desc.data.subimage[0][0] = sg.asRange(pixels);
+    img_desc.data.subimage[0][0] = sg.asRange(&pixels);
     state.img = sg.makeImage(img_desc);
 
     // create a pipeline object for 3d rendering, with less-equal

--- a/src/examples/shapes.zig
+++ b/src/examples/shapes.zig
@@ -69,8 +69,8 @@ export fn init() void {
     var vertices: [6*1024]sshape.Vertex = undefined;
     var indices:  [16*1024]u16 = undefined;
     var buf: sshape.Buffer = .{
-        .vertices = .{ .buffer = sshape.asRange(vertices) },
-        .indices  = .{ .buffer = sshape.asRange(indices) },
+        .vertices = .{ .buffer = sshape.asRange(&vertices) },
+        .indices  = .{ .buffer = sshape.asRange(&indices) },
     };
     buf = sshape.buildBox(buf, .{ .width=1.0, .height=1.0, .depth=1.0, .tiles=10, .random_colors=true });
     state.shapes[0].draw = sshape.elementRange(buf);
@@ -118,7 +118,7 @@ export fn frame() void {
         // per-shape model-view-projection matrix
         const model = mat4.mul(mat4.translate(shape.pos), rm);
         state.vs_params.mvp = mat4.mul(view_proj, model);
-        sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(state.vs_params));
+        sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(&state.vs_params));
         sg.draw(shape.draw.base_element, shape.draw.num_elements, 1);
     }
     sdtx.draw();

--- a/src/examples/texcube.zig
+++ b/src/examples/texcube.zig
@@ -20,7 +20,7 @@ const state = struct {
 };
 
 // a vertex struct with position, color and uv-coords
-const Vertex = packed struct {
+const Vertex = extern struct {
     x: f32, y: f32, z: f32,
     color: u32,
     u: i16, v: i16

--- a/src/examples/texcube.zig
+++ b/src/examples/texcube.zig
@@ -40,7 +40,7 @@ export fn init() void {
     // formats to floating point inputs (only to integer inputs),
     // and WebGL2 / GLES2 don't support integer vertex shader inputs.
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]Vertex{
+        .data = sg.asRange(&[_]Vertex{
             // pos                         color              texcoords
             .{ .x=-1.0, .y=-1.0, .z=-1.0,  .color=0xFF0000FF, .u=    0, .v=    0 },
             .{ .x= 1.0, .y=-1.0, .z=-1.0,  .color=0xFF0000FF, .u=32767, .v=    0 },
@@ -77,7 +77,7 @@ export fn init() void {
     // cube index buffer
     state.bind.index_buffer = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
-        .data = sg.asRange([_]u16{
+        .data = sg.asRange(&[_]u16{
             0, 1, 2,  0, 2, 3,
             6, 5, 4,  7, 6, 4,
             8, 9, 10,  8, 10, 11,
@@ -92,7 +92,7 @@ export fn init() void {
         .width = 4,
         .height = 4,
     };
-    img_desc.data.subimage[0][0] = sg.asRange([4*4]u32{
+    img_desc.data.subimage[0][0] = sg.asRange(&[4*4]u32{
         0xFFFFFFFF, 0xFF000000, 0xFFFFFFFF, 0xFF000000,
         0xFF000000, 0xFFFFFFFF, 0xFF000000, 0xFFFFFFFF,
         0xFFFFFFFF, 0xFF000000, 0xFFFFFFFF, 0xFF000000,
@@ -129,7 +129,7 @@ export fn frame() void {
     sg.beginDefaultPass(state.pass_action, sapp.width(), sapp.height());
     sg.applyPipeline(state.pip);
     sg.applyBindings(state.bind);
-    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(vs_params));
+    sg.applyUniforms(.VS, shd.SLOT_vs_params, sg.asRange(&vs_params));
     sg.draw(0, 36, 1);
     sg.endPass();
     sg.commit();

--- a/src/examples/triangle.zig
+++ b/src/examples/triangle.zig
@@ -19,7 +19,7 @@ export fn init() void {
 
     // create vertex buffer with triangle vertices
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange([_]f32{
+        .data = sg.asRange(&[_]f32{
             // positions         colors
              0.0,  0.5, 0.5,     1.0, 0.0, 0.0, 1.0,
              0.5, -0.5, 0.5,     0.0, 1.0, 0.0, 1.0,


### PR DESCRIPTION
- Uses the new `asRange` calling convention from https://github.com/floooh/sokol/pull/710
- Change `Mat4/Vec2/Vec3` to `extern struct` as arrays in packed structs are no longer supported, and a guaranteed memory layout is needed for passing these to the GPU

All the examples (except for `instancing.zig`) run for me on self-hosted (Windows, x86_64) in both opengl and directx. I did notice the point size seems different between dx and gl for sgl-points, but this seems true with `-fstage1` as well.

The `instancing.zig` example crashes on self-hosted with a stack overflow, at the start of `frame()`. Debugging this, it seems that it tries to pass ~40M to `___chkstk_ms`, which comes from `lib/compiler_rt/stack_probe.zig`. I recall seeing some activity about this so this may just be a self-hosted bug. I only have access to Windows, so it may not affect other platforms. This may also be related to the issue with structs being copied on to the stack (https://github.com/ziglang/zig/issues/12638) but I'm not familiar with how the stack probe is supposed to work, so I can't say without more investigating.