### PR TITLE
Add EGL support (And config struct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const sokol = @import("lib/sokol-zig/build.zig");
 // pub fn build(b: *std.build.Builder) void {
 // ...
 
-const sokol_build = sokol.buildSokol(b, target, mode, Backend.auto, "lib/sokol-zig/");
+const sokol_build = sokol.buildSokol(b, target, mode, .{}, "lib/sokol-zig/");
 
 // ...
 // const exe = b.addExecutable("demo", "src/main.zig");

--- a/build.zig
+++ b/build.zig
@@ -85,7 +85,7 @@ pub fn buildSokol(b: *Builder, target: CrossTarget, mode: Mode, config: Config, 
             } else {
                 lib.linkSystemLibrary("GL");
                 if (config.backend == .gles2) {
-                    @panic("GLES2 in Linux only available with force_egl");
+                    @panic("GLES2 in Linux only available with Config.use_egl");
                 }
             }
         }


### PR DESCRIPTION
Now that EGL support has been added to `sokol_app.h`, it would make sense that the zig counterpart would also support it as a flag or something related.

I wrote a small patch which would allow for the zig build process to link towards EGL and use the right flags.

Maybe this code is a bit dirty, but that's what pull requests are for :)