### PR TITLE
Use linkSystemLibraryName on Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -72,13 +72,13 @@ pub fn buildSokol(b: *Builder, target: CrossTarget, mode: Mode, backend: Backend
             lib.linkSystemLibrary("asound");
         }
         else if (lib.target.isWindows()) {
-            lib.linkSystemLibrary("kernel32");
-            lib.linkSystemLibrary("user32");
-            lib.linkSystemLibrary("gdi32");
-            lib.linkSystemLibrary("ole32");
+            lib.linkSystemLibraryName("kernel32");
+            lib.linkSystemLibraryName("user32");
+            lib.linkSystemLibraryName("gdi32");
+            lib.linkSystemLibraryName("ole32");
             if (.d3d11 == _backend) {
-                lib.linkSystemLibrary("d3d11");
-                lib.linkSystemLibrary("dxgi");
+                lib.linkSystemLibraryName("d3d11");
+                lib.linkSystemLibraryName("dxgi");
             }
         }
     }


### PR DESCRIPTION
Latest nightly Zig tries to run pkg-config and fails to build sokol-zig on Windows if you use linkSystemLibrary. Switching to linkSystemLibraryName does the right thing for now. I also tested with 0.10.0.

Not sure if this was intentional, but when I ran a pre-0.10.0 zig build under ProcMon for a bit looking at other issues I noticed it was just constantly invoking pkg-config, failing, and falling back to linking by name anyway. So I'm not sure if the "proper" way to link kernel32, etc. has been settled. 🤷 