### PR TITLE
Use `zig fmt` to fix the casting changes in the latest zig version

### DIFF
--- a/src/examples/blend.zig
+++ b/src/examples/blend.zig
@@ -3,13 +3,13 @@
 //  Test/demonstrate blend modes.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const vec3  = @import("math.zig").Vec3;
-const mat4  = @import("math.zig").Mat4;
-const shd   = @import("shaders/blend.glsl.zig");
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/blend.glsl.zig");
 
 const NUM_BLEND_FACTORS = 15;
 
@@ -34,13 +34,13 @@ export fn init() void {
     state.pass_action.stencil.action = .DONTCARE;
 
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange(&[_]f32 {
-             // pos               color
-            -1.0, -1.0, 0.0,  1.0, 0.0, 0.0, 0.5,
-             1.0, -1.0, 0.0,  0.0, 1.0, 0.0, 0.5,
-            -1.0,  1.0, 0.0,  0.0, 0.0, 1.0, 0.5,
-             1.0,  1.0, 0.0,  1.0, 1.0, 0.0, 0.5
-        })
+        .data = sg.asRange(&[_]f32{
+            // pos               color
+            -1.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.5,
+            1.0,  -1.0, 0.0, 0.0, 1.0, 0.0, 0.5,
+            -1.0, 1.0,  0.0, 0.0, 0.0, 1.0, 0.5,
+            1.0,  1.0,  0.0, 1.0, 1.0, 0.0, 0.5,
+        }),
     });
 
     // pipeline object for rendering the background
@@ -53,11 +53,7 @@ export fn init() void {
     state.bg_pip = sg.makePipeline(pip_desc);
 
     // lot of pipeline objects for rendering the blended quads
-    pip_desc = .{
-        .shader = sg.makeShader(shd.quadShaderDesc(sg.queryBackend())),
-        .primitive_type = .TRIANGLE_STRIP,
-        .blend_color = .{ .r=1.0, .g=0.0, .b=0.0, .a=1.0 }
-    };
+    pip_desc = .{ .shader = sg.makeShader(shd.quadShaderDesc(sg.queryBackend())), .primitive_type = .TRIANGLE_STRIP, .blend_color = .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 } };
     pip_desc.layout.attrs[shd.ATTR_vs_quad_position].format = .FLOAT3;
     pip_desc.layout.attrs[shd.ATTR_vs_quad_color0].format = .FLOAT4;
     pip_desc.colors[0].blend = .{
@@ -65,17 +61,19 @@ export fn init() void {
         .src_factor_alpha = .ONE,
         .dst_factor_alpha = .ZERO,
     };
-    var src: usize = 0; while (src < NUM_BLEND_FACTORS): (src += 1) {
-        var dst: usize = 0; while (dst < NUM_BLEND_FACTORS): (dst += 1) {
-            pip_desc.colors[0].blend.src_factor_rgb = @enumFromInt(sg.BlendFactor, src + 1);
-            pip_desc.colors[0].blend.dst_factor_rgb = @enumFromInt(sg.BlendFactor, dst + 1);
+    var src: usize = 0;
+    while (src < NUM_BLEND_FACTORS) : (src += 1) {
+        var dst: usize = 0;
+        while (dst < NUM_BLEND_FACTORS) : (dst += 1) {
+            pip_desc.colors[0].blend.src_factor_rgb = @as(sg.BlendFactor, @enumFromInt(src + 1));
+            pip_desc.colors[0].blend.dst_factor_rgb = @as(sg.BlendFactor, @enumFromInt(dst + 1));
             state.pip[src][dst] = sg.makePipeline(pip_desc);
         }
     }
 }
 
 export fn frame() void {
-    const time = @floatCast(f32, sapp.frameDuration()) * 60.0;
+    const time = @as(f32, @floatCast(sapp.frameDuration())) * 60.0;
 
     sg.beginDefaultPass(state.pass_action, sapp.width(), sapp.height());
 
@@ -94,19 +92,15 @@ export fn frame() void {
 
     state.r += 0.6 * time;
     var r0 = state.r;
-    var src: usize = 0; while (src < NUM_BLEND_FACTORS): (src += 1) {
-        var dst: usize = 0; while (dst < NUM_BLEND_FACTORS): (dst += 1) {
+    var src: usize = 0;
+    while (src < NUM_BLEND_FACTORS) : (src += 1) {
+        var dst: usize = 0;
+        while (dst < NUM_BLEND_FACTORS) : (dst += 1) {
             // compute model-view-proj matrix
             const shift = NUM_BLEND_FACTORS / 2;
-            const t: vec3 = .{
-                .x = (@floatFromInt(f32, dst) - shift) * 3.0,
-                .y = (@floatFromInt(f32, src) - shift) * 2.2,
-                .z = 0.0
-            };
+            const t: vec3 = .{ .x = (@as(f32, @floatFromInt(dst)) - shift) * 3.0, .y = (@as(f32, @floatFromInt(src)) - shift) * 2.2, .z = 0.0 };
             const model = mat4.mul(mat4.translate(t), mat4.rotate(r0, vec3.up()));
-            const quad_vs_params: shd.QuadVsParams = .{
-                .mvp = mat4.mul(view_proj, model)
-            };
+            const quad_vs_params: shd.QuadVsParams = .{ .mvp = mat4.mul(view_proj, model) };
             sg.applyPipeline(state.pip[src][dst]);
             sg.applyBindings(state.bind);
             sg.applyUniforms(.VS, shd.SLOT_quad_vs_params, sg.asRange(&quad_vs_params));

--- a/src/examples/blend.zig
+++ b/src/examples/blend.zig
@@ -67,8 +67,8 @@ export fn init() void {
     };
     var src: usize = 0; while (src < NUM_BLEND_FACTORS): (src += 1) {
         var dst: usize = 0; while (dst < NUM_BLEND_FACTORS): (dst += 1) {
-            pip_desc.colors[0].blend.src_factor_rgb = @intToEnum(sg.BlendFactor, src + 1);
-            pip_desc.colors[0].blend.dst_factor_rgb = @intToEnum(sg.BlendFactor, dst + 1);
+            pip_desc.colors[0].blend.src_factor_rgb = @enumFromInt(sg.BlendFactor, src + 1);
+            pip_desc.colors[0].blend.dst_factor_rgb = @enumFromInt(sg.BlendFactor, dst + 1);
             state.pip[src][dst] = sg.makePipeline(pip_desc);
         }
     }
@@ -99,8 +99,8 @@ export fn frame() void {
             // compute model-view-proj matrix
             const shift = NUM_BLEND_FACTORS / 2;
             const t: vec3 = .{
-                .x = (@intToFloat(f32, dst) - shift) * 3.0,
-                .y = (@intToFloat(f32, src) - shift) * 2.2,
+                .x = (@floatFromInt(f32, dst) - shift) * 3.0,
+                .y = (@floatFromInt(f32, src) - shift) * 2.2,
                 .z = 0.0
             };
             const model = mat4.mul(mat4.translate(t), mat4.rotate(r0, vec3.up()));

--- a/src/examples/blend.zig
+++ b/src/examples/blend.zig
@@ -53,7 +53,11 @@ export fn init() void {
     state.bg_pip = sg.makePipeline(pip_desc);
 
     // lot of pipeline objects for rendering the blended quads
-    pip_desc = .{ .shader = sg.makeShader(shd.quadShaderDesc(sg.queryBackend())), .primitive_type = .TRIANGLE_STRIP, .blend_color = .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 } };
+    pip_desc = .{
+        .shader = sg.makeShader(shd.quadShaderDesc(sg.queryBackend())),
+        .primitive_type = .TRIANGLE_STRIP,
+        .blend_color = .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 },
+    };
     pip_desc.layout.attrs[shd.ATTR_vs_quad_position].format = .FLOAT3;
     pip_desc.layout.attrs[shd.ATTR_vs_quad_color0].format = .FLOAT4;
     pip_desc.colors[0].blend = .{
@@ -98,9 +102,15 @@ export fn frame() void {
         while (dst < NUM_BLEND_FACTORS) : (dst += 1) {
             // compute model-view-proj matrix
             const shift = NUM_BLEND_FACTORS / 2;
-            const t: vec3 = .{ .x = (@as(f32, @floatFromInt(dst)) - shift) * 3.0, .y = (@as(f32, @floatFromInt(src)) - shift) * 2.2, .z = 0.0 };
+            const t: vec3 = .{
+                .x = (@as(f32, @floatFromInt(dst)) - shift) * 3.0,
+                .y = (@as(f32, @floatFromInt(src)) - shift) * 2.2,
+                .z = 0.0,
+            };
             const model = mat4.mul(mat4.translate(t), mat4.rotate(r0, vec3.up()));
-            const quad_vs_params: shd.QuadVsParams = .{ .mvp = mat4.mul(view_proj, model) };
+            const quad_vs_params: shd.QuadVsParams = .{
+                .mvp = mat4.mul(view_proj, model),
+            };
             sg.applyPipeline(state.pip[src][dst]);
             sg.applyBindings(state.bind);
             sg.applyUniforms(.VS, shd.SLOT_quad_vs_params, sg.asRange(&quad_vs_params));

--- a/src/examples/bufferoffsets.zig
+++ b/src/examples/bufferoffsets.zig
@@ -5,11 +5,11 @@
 //  buffer offsets.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const shd   = @import("shaders/bufferoffsets.glsl.zig");
+const shd = @import("shaders/bufferoffsets.glsl.zig");
 
 const state = struct {
     var pass_action: sg.PassAction = .{};
@@ -17,10 +17,7 @@ const state = struct {
     var bind: sg.Bindings = .{};
 };
 
-const Vertex = extern struct {
-    x: f32, y: f32,
-    r: f32, g: f32, b: f32
-};
+const Vertex = extern struct { x: f32, y: f32, r: f32, g: f32, b: f32 };
 
 export fn init() void {
     sg.setup(.{
@@ -29,22 +26,22 @@ export fn init() void {
     });
 
     // clear to a blue-ish color
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0.5, .g=0.5, .b=1, .a=1 } };
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.5, .g = 0.5, .b = 1, .a = 1 } };
 
     // a 2D triangle and quad in 1 vertex buffer and 1 index buffer
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
         .data = sg.asRange(&[_]Vertex{
             // triangle vertices
-            .{ .x= 0.0,  .y= 0.55,  .r=1.0, .g=0.0, .b=0.0 },
-            .{ .x= 0.25, .y= 0.05,  .r=0.0, .g=1.0, .b=0.0 },
-            .{ .x=-0.25, .y= 0.05,  .r=0.0, .g=0.0, .b=1.0 },
+            .{ .x = 0.0, .y = 0.55, .r = 1.0, .g = 0.0, .b = 0.0 },
+            .{ .x = 0.25, .y = 0.05, .r = 0.0, .g = 1.0, .b = 0.0 },
+            .{ .x = -0.25, .y = 0.05, .r = 0.0, .g = 0.0, .b = 1.0 },
 
             // quad vertices
-            .{ .x=-0.25, .y=-0.05,  .r=0.0, .g=0.0, .b=1.0 },
-            .{ .x= 0.25, .y=-0.05,  .r=0.0, .g=1.0, .b=0.0 },
-            .{ .x= 0.25, .y=-0.55,  .r=1.0, .g=0.0, .b=0.0 },
-            .{ .x=-0.25, .y=-0.55,  .r=1.0, .g=1.0, .b=0.0 }
-        })
+            .{ .x = -0.25, .y = -0.05, .r = 0.0, .g = 0.0, .b = 1.0 },
+            .{ .x = 0.25, .y = -0.05, .r = 0.0, .g = 1.0, .b = 0.0 },
+            .{ .x = 0.25, .y = -0.55, .r = 1.0, .g = 0.0, .b = 0.0 },
+            .{ .x = -0.25, .y = -0.55, .r = 1.0, .g = 1.0, .b = 0.0 },
+        }),
     });
     state.bind.index_buffer = sg.makeBuffer(.{
         .type = .INDEXBUFFER,
@@ -52,15 +49,13 @@ export fn init() void {
             // triangle indices
             0, 1, 2,
             // quad indices
-            0, 1, 2, 0, 2, 3
-        })
+            0, 1, 2,
+            0, 2, 3,
+        }),
     });
 
     // a shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{
-        .shader = sg.makeShader(shd.bufferoffsetsShaderDesc(sg.queryBackend())),
-        .index_type = .UINT16
-    };
+    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.bufferoffsetsShaderDesc(sg.queryBackend())), .index_type = .UINT16 };
     pip_desc.layout.attrs[shd.ATTR_vs_position].format = .FLOAT2;
     pip_desc.layout.attrs[shd.ATTR_vs_color0].format = .FLOAT3;
     state.pip = sg.makePipeline(pip_desc);

--- a/src/examples/bufferoffsets.zig
+++ b/src/examples/bufferoffsets.zig
@@ -17,7 +17,12 @@ const state = struct {
     var bind: sg.Bindings = .{};
 };
 
-const Vertex = extern struct { x: f32, y: f32, r: f32, g: f32, b: f32 };
+// zig fmt: off
+const Vertex = extern struct {
+    x: f32, y: f32,
+    r: f32, g: f32, b: f32,
+};
+// zig fmt: on
 
 export fn init() void {
     sg.setup(.{
@@ -55,7 +60,10 @@ export fn init() void {
     });
 
     // a shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.bufferoffsetsShaderDesc(sg.queryBackend())), .index_type = .UINT16 };
+    var pip_desc: sg.PipelineDesc = .{
+        .shader = sg.makeShader(shd.bufferoffsetsShaderDesc(sg.queryBackend())),
+        .index_type = .UINT16,
+    };
     pip_desc.layout.attrs[shd.ATTR_vs_position].format = .FLOAT2;
     pip_desc.layout.attrs[shd.ATTR_vs_color0].format = .FLOAT3;
     state.pip = sg.makePipeline(pip_desc);

--- a/src/examples/clear.zig
+++ b/src/examples/clear.zig
@@ -13,7 +13,12 @@ const print = @import("std").debug.print;
 var pass_action: sg.PassAction = .{};
 
 export fn init() void {
-    sg.setup(.{ .context = sgapp.context(), .logger = .{ .func = slog.func } });
+    sg.setup(.{
+        .context = sgapp.context(),
+        .logger = .{
+            .func = slog.func,
+        },
+    });
     pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 1, .g = 1, .b = 0, .a = 1 } };
     print("Backend: {}\n", .{sg.queryBackend()});
 }

--- a/src/examples/clear.zig
+++ b/src/examples/clear.zig
@@ -4,21 +4,18 @@
 //  Just clear the framebuffer with an animated color.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
 const print = @import("std").debug.print;
 
 var pass_action: sg.PassAction = .{};
 
 export fn init() void {
-    sg.setup(.{
-        .context = sgapp.context(),
-        .logger = .{ .func = slog.func }
-    });
-    pass_action.colors[0] = .{ .action=.CLEAR, .value=.{ .r=1, .g=1, .b=0, .a=1 } };
-    print("Backend: {}\n", .{ sg.queryBackend()});
+    sg.setup(.{ .context = sgapp.context(), .logger = .{ .func = slog.func } });
+    pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 1, .g = 1, .b = 0, .a = 1 } };
+    print("Backend: {}\n", .{sg.queryBackend()});
 }
 
 export fn frame() void {

--- a/src/examples/cube.zig
+++ b/src/examples/cube.zig
@@ -64,13 +64,28 @@ export fn init() void {
     });
 
     // cube index buffer
-    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
+    state.bind.index_buffer = sg.makeBuffer(.{
+        .type = .INDEXBUFFER,
+        .data = sg.asRange(&[_]u16{
+            0,  1,  2,  0,  2,  3,
+            6,  5,  4,  7,  6,  4,
+            8,  9,  10, 8,  10, 11,
+            14, 13, 12, 15, 14, 12,
+            16, 17, 18, 16, 18, 19,
+            22, 21, 20, 23, 22, 20,
+        }),
+    });
 
     // shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.cubeShaderDesc(sg.queryBackend())), .index_type = .UINT16, .depth = .{
-        .compare = .LESS_EQUAL,
-        .write_enabled = true,
-    }, .cull_mode = .BACK };
+    var pip_desc: sg.PipelineDesc = .{
+        .shader = sg.makeShader(shd.cubeShaderDesc(sg.queryBackend())),
+        .index_type = .UINT16,
+        .depth = .{
+            .compare = .LESS_EQUAL,
+            .write_enabled = true,
+        },
+        .cull_mode = .BACK,
+    };
     pip_desc.layout.attrs[shd.ATTR_vs_position].format = .FLOAT3;
     pip_desc.layout.attrs[shd.ATTR_vs_color0].format = .FLOAT4;
     state.pip = sg.makePipeline(pip_desc);

--- a/src/examples/cube.zig
+++ b/src/examples/cube.zig
@@ -4,13 +4,13 @@
 //  Shader with uniform data.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const vec3  = @import("math.zig").Vec3;
-const mat4  = @import("math.zig").Mat4;
-const shd   = @import("shaders/cube.glsl.zig");
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/cube.glsl.zig");
 
 const state = struct {
     var rx: f32 = 0.0;
@@ -18,7 +18,7 @@ const state = struct {
     var pip: sg.Pipeline = .{};
     var bind: sg.Bindings = .{};
     var pass_action: sg.PassAction = .{};
-    const view: mat4 = mat4.lookat(.{ .x=0.0, .y=1.5, .z=6.0 }, vec3.zero(), vec3.up());
+    const view: mat4 = mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 6.0 }, vec3.zero(), vec3.up());
 };
 
 export fn init() void {
@@ -29,73 +29,58 @@ export fn init() void {
 
     // cube vertex buffer
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange(&[_]f32 {
+        .data = sg.asRange(&[_]f32{
             // positions        colors
-            -1.0, -1.0, -1.0,   1.0, 0.0, 0.0, 1.0,
-             1.0, -1.0, -1.0,   1.0, 0.0, 0.0, 1.0,
-             1.0,  1.0, -1.0,   1.0, 0.0, 0.0, 1.0,
-            -1.0,  1.0, -1.0,   1.0, 0.0, 0.0, 1.0,
+            -1.0, -1.0, -1.0, 1.0, 0.0, 0.0, 1.0,
+            1.0,  -1.0, -1.0, 1.0, 0.0, 0.0, 1.0,
+            1.0,  1.0,  -1.0, 1.0, 0.0, 0.0, 1.0,
+            -1.0, 1.0,  -1.0, 1.0, 0.0, 0.0, 1.0,
 
-            -1.0, -1.0,  1.0,   0.0, 1.0, 0.0, 1.0,
-             1.0, -1.0,  1.0,   0.0, 1.0, 0.0, 1.0,
-             1.0,  1.0,  1.0,   0.0, 1.0, 0.0, 1.0,
-            -1.0,  1.0,  1.0,   0.0, 1.0, 0.0, 1.0,
+            -1.0, -1.0, 1.0,  0.0, 1.0, 0.0, 1.0,
+            1.0,  -1.0, 1.0,  0.0, 1.0, 0.0, 1.0,
+            1.0,  1.0,  1.0,  0.0, 1.0, 0.0, 1.0,
+            -1.0, 1.0,  1.0,  0.0, 1.0, 0.0, 1.0,
 
-            -1.0, -1.0, -1.0,   0.0, 0.0, 1.0, 1.0,
-            -1.0,  1.0, -1.0,   0.0, 0.0, 1.0, 1.0,
-            -1.0,  1.0,  1.0,   0.0, 0.0, 1.0, 1.0,
-            -1.0, -1.0,  1.0,   0.0, 0.0, 1.0, 1.0,
+            -1.0, -1.0, -1.0, 0.0, 0.0, 1.0, 1.0,
+            -1.0, 1.0,  -1.0, 0.0, 0.0, 1.0, 1.0,
+            -1.0, 1.0,  1.0,  0.0, 0.0, 1.0, 1.0,
+            -1.0, -1.0, 1.0,  0.0, 0.0, 1.0, 1.0,
 
-            1.0, -1.0, -1.0,    1.0, 0.5, 0.0, 1.0,
-            1.0,  1.0, -1.0,    1.0, 0.5, 0.0, 1.0,
-            1.0,  1.0,  1.0,    1.0, 0.5, 0.0, 1.0,
-            1.0, -1.0,  1.0,    1.0, 0.5, 0.0, 1.0,
+            1.0,  -1.0, -1.0, 1.0, 0.5, 0.0, 1.0,
+            1.0,  1.0,  -1.0, 1.0, 0.5, 0.0, 1.0,
+            1.0,  1.0,  1.0,  1.0, 0.5, 0.0, 1.0,
+            1.0,  -1.0, 1.0,  1.0, 0.5, 0.0, 1.0,
 
-            -1.0, -1.0, -1.0,   0.0, 0.5, 1.0, 1.0,
-            -1.0, -1.0,  1.0,   0.0, 0.5, 1.0, 1.0,
-             1.0, -1.0,  1.0,   0.0, 0.5, 1.0, 1.0,
-             1.0, -1.0, -1.0,   0.0, 0.5, 1.0, 1.0,
+            -1.0, -1.0, -1.0, 0.0, 0.5, 1.0, 1.0,
+            -1.0, -1.0, 1.0,  0.0, 0.5, 1.0, 1.0,
+            1.0,  -1.0, 1.0,  0.0, 0.5, 1.0, 1.0,
+            1.0,  -1.0, -1.0, 0.0, 0.5, 1.0, 1.0,
 
-            -1.0,  1.0, -1.0,   1.0, 0.0, 0.5, 1.0,
-            -1.0,  1.0,  1.0,   1.0, 0.0, 0.5, 1.0,
-             1.0,  1.0,  1.0,   1.0, 0.0, 0.5, 1.0,
-             1.0,  1.0, -1.0,   1.0, 0.0, 0.5, 1.0
-        })
+            -1.0, 1.0,  -1.0, 1.0, 0.0, 0.5, 1.0,
+            -1.0, 1.0,  1.0,  1.0, 0.0, 0.5, 1.0,
+            1.0,  1.0,  1.0,  1.0, 0.0, 0.5, 1.0,
+            1.0,  1.0,  -1.0, 1.0, 0.0, 0.5, 1.0,
+        }),
     });
 
     // cube index buffer
-    state.bind.index_buffer = sg.makeBuffer(.{
-        .type = .INDEXBUFFER,
-        .data = sg.asRange(&[_]u16{
-            0, 1, 2,  0, 2, 3,
-            6, 5, 4,  7, 6, 4,
-            8, 9, 10,  8, 10, 11,
-            14, 13, 12,  15, 14, 12,
-            16, 17, 18,  16, 18, 19,
-            22, 21, 20,  23, 22, 20
-        })
-    });
+    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
 
     // shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{
-        .shader = sg.makeShader(shd.cubeShaderDesc(sg.queryBackend())),
-        .index_type = .UINT16,
-        .depth = .{
-            .compare = .LESS_EQUAL,
-            .write_enabled = true,
-        },
-        .cull_mode = .BACK
-    };
+    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.cubeShaderDesc(sg.queryBackend())), .index_type = .UINT16, .depth = .{
+        .compare = .LESS_EQUAL,
+        .write_enabled = true,
+    }, .cull_mode = .BACK };
     pip_desc.layout.attrs[shd.ATTR_vs_position].format = .FLOAT3;
     pip_desc.layout.attrs[shd.ATTR_vs_color0].format = .FLOAT4;
     state.pip = sg.makePipeline(pip_desc);
 
     // framebuffer clear color
-    state.pass_action.colors[0] = .{ .action=.CLEAR, .value = .{ .r=0.25, .g=0.5, .b=0.75, .a=1 } };
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.25, .g = 0.5, .b = 0.75, .a = 1 } };
 }
 
 export fn frame() void {
-    const dt = @floatCast(f32, sapp.frameDuration() * 60);
+    const dt = @as(f32, @floatCast(sapp.frameDuration() * 60));
     state.rx += 1.0 * dt;
     state.ry += 2.0 * dt;
     const vs_params = computeVsParams(state.rx, state.ry);
@@ -128,12 +113,10 @@ pub fn main() void {
 }
 
 fn computeVsParams(rx: f32, ry: f32) shd.VsParams {
-    const rxm = mat4.rotate(rx, .{ .x=1.0, .y=0.0, .z=0.0 });
-    const rym = mat4.rotate(ry, .{ .x=0.0, .y=1.0, .z=0.0 });
+    const rxm = mat4.rotate(rx, .{ .x = 1.0, .y = 0.0, .z = 0.0 });
+    const rym = mat4.rotate(ry, .{ .x = 0.0, .y = 1.0, .z = 0.0 });
     const model = mat4.mul(rxm, rym);
     const aspect = sapp.widthf() / sapp.heightf();
     const proj = mat4.persp(60.0, aspect, 0.01, 10.0);
-    return shd.VsParams {
-        .mvp = mat4.mul(mat4.mul(proj, state.view), model)
-    };
+    return shd.VsParams{ .mvp = mat4.mul(mat4.mul(proj, state.view), model) };
 }

--- a/src/examples/debugtext-print.zig
+++ b/src/examples/debugtext-print.zig
@@ -4,12 +4,12 @@
 //  Demonstrates formatted printing with sokol.debugtext
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const stm   = sokol.time;
-const sdtx  = @import("sokol").debugtext;
+const stm = sokol.time;
+const sdtx = @import("sokol").debugtext;
 
 // only needed when using std.fmt directly instead of sokol.debugtext.print()
 const fmt = @import("std").fmt;
@@ -19,18 +19,16 @@ const KC854 = 0;
 const C64 = 1;
 const ORIC = 2;
 
-const Color = struct {
-    r: u8, g: u8, b: u8
-};
+const Color = struct { r: u8, g: u8, b: u8 };
 
 const state = struct {
     var pass_action: sg.PassAction = .{};
     var frame_count: u32 = 0;
     var time_stamp: u64 = 0;
-    const colors = [_]Color {
-        .{ .r=0xf4, .g=0x43, .b=0x36 },
-        .{ .r=0x21, .g=0x96, .b=0xf3 },
-        .{ .r=0x4c, .g=0xaf, .b=0x50 },
+    const colors = [_]Color{
+        .{ .r = 0xf4, .g = 0x43, .b = 0x36 },
+        .{ .r = 0x21, .g = 0x96, .b = 0xf3 },
+        .{ .r = 0x4c, .g = 0xaf, .b = 0x50 },
     };
 };
 
@@ -50,7 +48,7 @@ export fn init() void {
     sdtx.setup(sdtx_desc);
 
     // pass-action for clearing to blue-ish
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0.125, .b=0.25, .a=1 }};
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0.125, .b = 0.25, .a = 1 } };
 }
 
 export fn frame() void {
@@ -60,13 +58,13 @@ export fn frame() void {
     sdtx.canvas(sapp.widthf() * 0.5, sapp.heightf() * 0.5);
     sdtx.origin(3, 3);
 
-    inline for (.{KC854, C64, ORIC}) |font| {
+    inline for (.{ KC854, C64, ORIC }) |font| {
         const color = state.colors[font];
         sdtx.font(font);
         sdtx.color3b(color.r, color.g, color.b);
-        const world_str = if (0 == (state.frame_count & (1<<7))) "Welt" else "World";
-        sdtx.print("Hello '{s}'!\n", .{ world_str });
-        sdtx.print("\tFrame Time:\t\t{d:.3}ms\n", .{ frame_time });
+        const world_str = if (0 == (state.frame_count & (1 << 7))) "Welt" else "World";
+        sdtx.print("Hello '{s}'!\n", .{world_str});
+        sdtx.print("\tFrame Time:\t\t{d:.3}ms\n", .{frame_time});
         sdtx.print("\tFrame Count:\t{d}\t0x{X:0>4}\n", .{ state.frame_count, state.frame_count });
         sdtx.moveY(2);
     }
@@ -75,7 +73,7 @@ export fn frame() void {
 
     // can also use sdtx.Writer with std.fmt directly:
     var writer: sdtx.Writer = .{};
-    fmt.format(writer, "using std.fmt directly ({d})\n", .{ state.frame_count }) catch unreachable;
+    fmt.format(writer, "using std.fmt directly ({d})\n", .{state.frame_count}) catch unreachable;
 
     // render the frame via sokol.gfx
     sg.beginDefaultPass(state.pass_action, sapp.width(), sapp.height());

--- a/src/examples/debugtext-userfont.zig
+++ b/src/examples/debugtext-userfont.zig
@@ -53,7 +53,11 @@ export fn init() void {
     // NOTE that the user font only provides pixel data for the
     // characters 0x20 to 0x9F (inclusive)
     var sdtx_desc: sdtx.Desc = .{ .logger = .{ .func = slog.func } };
-    sdtx_desc.fonts[UserFont] = .{ .data = sdtx.asRange(&user_font), .first_char = 0x20, .last_char = 0x9F };
+    sdtx_desc.fonts[UserFont] = .{
+        .data = sdtx.asRange(&user_font),
+        .first_char = 0x20,
+        .last_char = 0x9F,
+    };
     sdtx.setup(sdtx_desc);
 
     // pass-action to clear background to blue-ish

--- a/src/examples/debugtext-userfont.zig
+++ b/src/examples/debugtext-userfont.zig
@@ -4,40 +4,42 @@
 //  How to use a user-defined font with sokol.debugtext
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const sdtx  = sokol.debugtext;
+const sdtx = sokol.debugtext;
 
 // use font-slot 1 for the user-defined font, there's no particular
 // reason why this isn't 0, except for testing
 const UserFont = 1;
 
 const Color = struct {
-    r: u8, g: u8, b: u8,
+    r: u8,
+    g: u8,
+    b: u8,
 };
 
 const state = struct {
     var pass_action: sg.PassAction = .{};
     var frame_count: u32 = 0;
-    const color_palette = [_]Color {
-        .{ .r=0xf4, .g=0x43, .b=0x36 },
-        .{ .r=0xe9, .g=0x1e, .b=0x63 },
-        .{ .r=0x9c, .g=0x27, .b=0xb0 },
-        .{ .r=0x67, .g=0x3a, .b=0xb7 },
-        .{ .r=0x3f, .g=0x51, .b=0xb5 },
-        .{ .r=0x21, .g=0x96, .b=0xf3 },
-        .{ .r=0x03, .g=0xa9, .b=0xf4 },
-        .{ .r=0x00, .g=0xbc, .b=0xd4 },
-        .{ .r=0x00, .g=0x96, .b=0x88 },
-        .{ .r=0x4c, .g=0xaf, .b=0x50 },
-        .{ .r=0x8b, .g=0xc3, .b=0x4a },
-        .{ .r=0xcd, .g=0xdc, .b=0x39 },
-        .{ .r=0xff, .g=0xeb, .b=0x3b },
-        .{ .r=0xff, .g=0xc1, .b=0x07 },
-        .{ .r=0xff, .g=0x98, .b=0x00 },
-        .{ .r=0xff, .g=0x57, .b=0x22 },
+    const color_palette = [_]Color{
+        .{ .r = 0xf4, .g = 0x43, .b = 0x36 },
+        .{ .r = 0xe9, .g = 0x1e, .b = 0x63 },
+        .{ .r = 0x9c, .g = 0x27, .b = 0xb0 },
+        .{ .r = 0x67, .g = 0x3a, .b = 0xb7 },
+        .{ .r = 0x3f, .g = 0x51, .b = 0xb5 },
+        .{ .r = 0x21, .g = 0x96, .b = 0xf3 },
+        .{ .r = 0x03, .g = 0xa9, .b = 0xf4 },
+        .{ .r = 0x00, .g = 0xbc, .b = 0xd4 },
+        .{ .r = 0x00, .g = 0x96, .b = 0x88 },
+        .{ .r = 0x4c, .g = 0xaf, .b = 0x50 },
+        .{ .r = 0x8b, .g = 0xc3, .b = 0x4a },
+        .{ .r = 0xcd, .g = 0xdc, .b = 0x39 },
+        .{ .r = 0xff, .g = 0xeb, .b = 0x3b },
+        .{ .r = 0xff, .g = 0xc1, .b = 0x07 },
+        .{ .r = 0xff, .g = 0x98, .b = 0x00 },
+        .{ .r = 0xff, .g = 0x57, .b = 0x22 },
     };
 };
 
@@ -50,16 +52,12 @@ export fn init() void {
     // setup sokol.debugtext with a user-defined font as the only font
     // NOTE that the user font only provides pixel data for the
     // characters 0x20 to 0x9F (inclusive)
-    var sdtx_desc: sdtx.Desc = .{ .logger = .{ .func = slog.func }};
-    sdtx_desc.fonts[UserFont] = .{
-        .data = sdtx.asRange(&user_font),
-        .first_char = 0x20,
-        .last_char = 0x9F
-    };
+    var sdtx_desc: sdtx.Desc = .{ .logger = .{ .func = slog.func } };
+    sdtx_desc.fonts[UserFont] = .{ .data = sdtx.asRange(&user_font), .first_char = 0x20, .last_char = 0x9F };
     sdtx.setup(sdtx_desc);
 
     // pass-action to clear background to blue-ish
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0.125, .b=0.25, .a=1 }};
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0.125, .b = 0.25, .a = 1 } };
 }
 
 export fn frame() void {
@@ -72,7 +70,7 @@ export fn frame() void {
     sdtx.puts("Hello 8-bit ATARI font:\n\n");
     var line: u32 = 0;
     var c: u8 = 0x20;
-    while (c < 0xA0): (c += 1) {
+    while (c < 0xA0) : (c += 1) {
         if ((c & 15) == 0) {
             sdtx.puts("\n\t");
             line += 1;
@@ -110,7 +108,7 @@ pub fn main() void {
 // Font data extracted from Atari 400 ROM at address 0xE000,
 // and reshuffled to map to ASCII. Each character is 8 bytes,
 // 1 bit per pixel in an 8x8 matrix.
-const user_font = [128*8]u8 {
+const user_font = [128 * 8]u8{
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 20
     0x00, 0x18, 0x18, 0x18, 0x18, 0x00, 0x18, 0x00, // 21
     0x00, 0x66, 0x66, 0x66, 0x00, 0x00, 0x00, 0x00, // 22

--- a/src/examples/debugtext.zig
+++ b/src/examples/debugtext.zig
@@ -4,19 +4,19 @@
 //  Basic test and demo for the sokol.debugtext module
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const sdtx  = sokol.debugtext;
+const sdtx = sokol.debugtext;
 
 // font indices
 const KC853 = 0;
 const KC854 = 1;
 const Z1013 = 2;
-const CPC   = 3;
-const C64   = 4;
-const ORIC  = 5;
+const CPC = 3;
+const C64 = 4;
+const ORIC = 5;
 
 var pass_action: sg.PassAction = .{};
 
@@ -31,12 +31,12 @@ export fn init() void {
     sdtx_desc.fonts[KC853] = sdtx.fontKc853();
     sdtx_desc.fonts[KC854] = sdtx.fontKc854();
     sdtx_desc.fonts[Z1013] = sdtx.fontZ1013();
-    sdtx_desc.fonts[CPC]   = sdtx.fontCpc();
-    sdtx_desc.fonts[C64]   = sdtx.fontC64();
-    sdtx_desc.fonts[ORIC]  = sdtx.fontOric();
+    sdtx_desc.fonts[CPC] = sdtx.fontCpc();
+    sdtx_desc.fonts[C64] = sdtx.fontC64();
+    sdtx_desc.fonts[ORIC] = sdtx.fontOric();
     sdtx.setup(sdtx_desc);
 
-    pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0.125, .b=0.25, .a=1 }};
+    pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0.125, .b = 0.25, .a = 1 } };
 }
 
 // print all characters in a font
@@ -45,8 +45,8 @@ fn printFont(font_index: u32, title: [:0]const u8, r: u8, g: u8, b: u8) void {
     sdtx.color3b(r, g, b);
     sdtx.puts(title);
     var c: u16 = 32;
-    while (c < 256): (c += 1) {
-        sdtx.putc(@intCast(u8, c));
+    while (c < 256) : (c += 1) {
+        sdtx.putc(@as(u8, @intCast(c)));
         if (((c + 1) & 63) == 0) {
             sdtx.crlf();
         }
@@ -57,17 +57,17 @@ fn printFont(font_index: u32, title: [:0]const u8, r: u8, g: u8, b: u8) void {
 export fn frame() void {
     // set virtual canvas size to half display size so that
     // glyphs are 16x16 display pixels
-    sdtx.canvas(sapp.widthf()*0.5, sapp.heightf()*0.5);
+    sdtx.canvas(sapp.widthf() * 0.5, sapp.heightf() * 0.5);
     sdtx.origin(0.0, 2.0);
     sdtx.home();
 
     // draw all font characters
-    printFont(KC853, "KC85/3:\n",      0xf4, 0x43, 0x36);
-    printFont(KC854, "KC85/4:\n",      0x21, 0x96, 0xf3);
-    printFont(Z1013, "Z1013:\n",       0x4c, 0xaf, 0x50);
-    printFont(CPC,   "Amstrad CPC:\n", 0xff, 0xeb, 0x3b);
-    printFont(C64,   "C64:\n",         0x79, 0x86, 0xcb);
-    printFont(ORIC,  "Oric Atmos:\n",  0xff, 0x98, 0x00);
+    printFont(KC853, "KC85/3:\n", 0xf4, 0x43, 0x36);
+    printFont(KC854, "KC85/4:\n", 0x21, 0x96, 0xf3);
+    printFont(Z1013, "Z1013:\n", 0x4c, 0xaf, 0x50);
+    printFont(CPC, "Amstrad CPC:\n", 0xff, 0xeb, 0x3b);
+    printFont(C64, "C64:\n", 0x79, 0x86, 0xcb);
+    printFont(ORIC, "Oric Atmos:\n", 0xff, 0x98, 0x00);
 
     // do the actual rendering
     sg.beginDefaultPass(pass_action, sapp.width(), sapp.height());

--- a/src/examples/instancing.zig
+++ b/src/examples/instancing.zig
@@ -40,13 +40,31 @@ export fn init() void {
 
     // a vertex buffer for the static particle geometry, goes into vertex buffer slot 0
     const r = 0.05;
-    state.bind.vertex_buffers[0] = sg.makeBuffer(.{ .data = sg.asRange(&[_]f32{ 0.0, -r, 0.0, 1.0, 0.0, 0.0, 1.0, r, 0.0, r, 0.0, 1.0, 0.0, 1.0, r, 0.0, -r, 0.0, 0.0, 1.0, 1.0, -r, 0.0, -r, 1.0, 1.0, 0.0, 1.0, -r, 0.0, r, 0.0, 1.0, 1.0, 1.0, 0.0, r, 0.0, 1.0, 0.0, 1.0, 1.0 }) });
+    state.bind.vertex_buffers[0] = sg.makeBuffer(.{
+        .data = sg.asRange(&[_]f32{
+            0.0, -r,  0.0, 1.0, 0.0, 0.0, 1.0,
+            r,   0.0, r,   0.0, 1.0, 0.0, 1.0,
+            r,   0.0, -r,  0.0, 0.0, 1.0, 1.0,
+            -r,  0.0, -r,  1.0, 1.0, 0.0, 1.0,
+            -r,  0.0, r,   0.0, 1.0, 1.0, 1.0,
+            0.0, r,   0.0, 1.0, 0.0, 1.0, 1.0,
+        }),
+    });
 
     // an index buffer for the static geometry
-    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 2, 1, 0, 3, 2, 0, 4, 3, 0, 1, 4, 0, 5, 1, 2, 5, 2, 3, 5, 3, 4, 5, 4, 1 }) });
+    state.bind.index_buffer = sg.makeBuffer(.{
+        .type = .INDEXBUFFER,
+        .data = sg.asRange(&[_]u16{
+            2, 1, 0, 3, 2, 0, 4, 3, 0, 1, 4, 0,
+            5, 1, 2, 5, 2, 3, 5, 3, 4, 5, 4, 1,
+        }),
+    });
 
     // an empty dynamic vertex buffer for the instancing data, goes in vertex buffer slot 1
-    state.bind.vertex_buffers[1] = sg.makeBuffer(.{ .usage = .STREAM, .size = max_particles * @sizeOf(vec3) });
+    state.bind.vertex_buffers[1] = sg.makeBuffer(.{
+        .usage = .STREAM,
+        .size = max_particles * @sizeOf(vec3),
+    });
 
     // shader and pipeline object
     var pip_desc: sg.PipelineDesc = .{
@@ -131,9 +149,7 @@ pub fn main() void {
         .width = 800,
         .height = 600,
         .sample_count = 4,
-        .icon = .{
-            .sokol_default = true,
-        },
+        .icon = .{ .sokol_default = true },
         .window_title = "instancing.zig",
         .logger = .{ .func = slog.func },
     });

--- a/src/examples/instancing.zig
+++ b/src/examples/instancing.zig
@@ -5,13 +5,13 @@
 //  and a dynamic instance-data buffer.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const vec3  = @import("math.zig").Vec3;
-const mat4  = @import("math.zig").Mat4;
-const shd   = @import("shaders/instancing.glsl.zig");
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/instancing.glsl.zig");
 
 const max_particles: usize = 512 * 1024;
 const num_particles_emitted_per_frame: usize = 10;
@@ -23,7 +23,7 @@ const state = struct {
     var ry: f32 = 0.0;
     var cur_num_particles: u32 = 0;
     // view matrix doesn't change
-    const view: mat4 = mat4.lookat(.{ .x=0.0, .y=1.5, .z=12.0 }, vec3.zero(), vec3.up());
+    const view: mat4 = mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 12.0 }, vec3.zero(), vec3.up());
     // un-initialized particle buffer to not bloat the executable
     var pos: [max_particles]vec3 = undefined;
     var vel: [max_particles]vec3 = undefined;
@@ -36,35 +36,17 @@ export fn init() void {
     });
 
     // pass action to clear frame buffer to black
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0, .b=0, .a=1 } };
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0, .a = 1 } };
 
     // a vertex buffer for the static particle geometry, goes into vertex buffer slot 0
     const r = 0.05;
-    state.bind.vertex_buffers[0] = sg.makeBuffer(.{
-        .data = sg.asRange(&[_]f32{
-            0.0,  -r, 0.0,   1.0, 0.0, 0.0, 1.0,
-              r, 0.0, r,     0.0, 1.0, 0.0, 1.0,
-              r, 0.0, -r,    0.0, 0.0, 1.0, 1.0,
-             -r, 0.0, -r,    1.0, 1.0, 0.0, 1.0,
-             -r, 0.0, r,     0.0, 1.0, 1.0, 1.0,
-            0.0,   r, 0.0,   1.0, 0.0, 1.0, 1.0
-        })
-    });
+    state.bind.vertex_buffers[0] = sg.makeBuffer(.{ .data = sg.asRange(&[_]f32{ 0.0, -r, 0.0, 1.0, 0.0, 0.0, 1.0, r, 0.0, r, 0.0, 1.0, 0.0, 1.0, r, 0.0, -r, 0.0, 0.0, 1.0, 1.0, -r, 0.0, -r, 1.0, 1.0, 0.0, 1.0, -r, 0.0, r, 0.0, 1.0, 1.0, 1.0, 0.0, r, 0.0, 1.0, 0.0, 1.0, 1.0 }) });
 
     // an index buffer for the static geometry
-    state.bind.index_buffer = sg.makeBuffer(.{
-        .type = .INDEXBUFFER,
-        .data = sg.asRange(&[_]u16{
-            2, 1, 0,  3, 2, 0,  4, 3, 0,  1, 4, 0,
-            5, 1, 2,  5, 2, 3,  5, 3, 4,  5, 4, 1
-        })
-    });
+    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 2, 1, 0, 3, 2, 0, 4, 3, 0, 1, 4, 0, 5, 1, 2, 5, 2, 3, 5, 3, 4, 5, 4, 1 }) });
 
     // an empty dynamic vertex buffer for the instancing data, goes in vertex buffer slot 1
-    state.bind.vertex_buffers[1] = sg.makeBuffer(.{
-        .usage = .STREAM,
-        .size = max_particles * @sizeOf(vec3)
-    });
+    state.bind.vertex_buffers[1] = sg.makeBuffer(.{ .usage = .STREAM, .size = max_particles * @sizeOf(vec3) });
 
     // shader and pipeline object
     var pip_desc: sg.PipelineDesc = .{
@@ -79,30 +61,25 @@ export fn init() void {
     // NOTE how the vertex layout is setup for instancing, with the instancing
     // data provided by buffer-slot 1:
     pip_desc.layout.buffers[1].step_func = .PER_INSTANCE;
-    pip_desc.layout.attrs[shd.ATTR_vs_pos]      = .{ .format = .FLOAT3, .buffer_index = 0 }; // positions
-    pip_desc.layout.attrs[shd.ATTR_vs_color0]   = .{ .format = .FLOAT4, .buffer_index = 0 }; // colors
+    pip_desc.layout.attrs[shd.ATTR_vs_pos] = .{ .format = .FLOAT3, .buffer_index = 0 }; // positions
+    pip_desc.layout.attrs[shd.ATTR_vs_color0] = .{ .format = .FLOAT4, .buffer_index = 0 }; // colors
     pip_desc.layout.attrs[shd.ATTR_vs_inst_pos] = .{ .format = .FLOAT3, .buffer_index = 1 }; // instance positions
 
     state.pip = sg.makePipeline(pip_desc);
 }
 
 export fn frame() void {
-    const frame_time = @floatCast(f32, sapp.frameDuration());
+    const frame_time = @as(f32, @floatCast(sapp.frameDuration()));
 
     // emit new particles
     {
         var i: usize = 0;
-        while (i < num_particles_emitted_per_frame): (i += 1) {
+        while (i < num_particles_emitted_per_frame) : (i += 1) {
             if (state.cur_num_particles < max_particles) {
                 state.pos[state.cur_num_particles] = vec3.zero();
-                state.vel[state.cur_num_particles] = .{
-                    .x = rand(-0.5, 0.5),
-                    .y = rand(2.0, 2.5),
-                    .z = rand(-0.5, 0.5)
-                };
+                state.vel[state.cur_num_particles] = .{ .x = rand(-0.5, 0.5), .y = rand(2.0, 2.5), .z = rand(-0.5, 0.5) };
                 state.cur_num_particles += 1;
-            }
-            else {
+            } else {
                 break;
             }
         }
@@ -111,7 +88,7 @@ export fn frame() void {
     // update particle positions
     {
         var i: usize = 0;
-        while (i < max_particles): (i += 1) {
+        while (i < max_particles) : (i += 1) {
             const vel = &state.vel[i];
             const pos = &state.pos[i];
 
@@ -154,21 +131,21 @@ pub fn main() void {
         .width = 800,
         .height = 600,
         .sample_count = 4,
-        .icon = .{ .sokol_default = true, },
+        .icon = .{
+            .sokol_default = true,
+        },
         .window_title = "instancing.zig",
         .logger = .{ .func = slog.func },
     });
 }
 
 fn computeVsParams(rx: f32, ry: f32) shd.VsParams {
-    const rxm = mat4.rotate(rx, .{ .x=1.0, .y=0.0, .z=0.0 });
-    const rym = mat4.rotate(ry, .{ .x=0.0, .y=1.0, .z=0.0 });
+    const rxm = mat4.rotate(rx, .{ .x = 1.0, .y = 0.0, .z = 0.0 });
+    const rym = mat4.rotate(ry, .{ .x = 0.0, .y = 1.0, .z = 0.0 });
     const model = mat4.mul(rxm, rym);
     const aspect = sapp.widthf() / sapp.heightf();
     const proj = mat4.persp(60.0, aspect, 0.01, 50.0);
-    return shd.VsParams {
-        .mvp = mat4.mul(mat4.mul(proj, state.view), model)
-    };
+    return shd.VsParams{ .mvp = mat4.mul(mat4.mul(proj, state.view), model) };
 }
 
 fn xorshift32() u32 {
@@ -184,5 +161,5 @@ fn xorshift32() u32 {
 }
 
 fn rand(min_val: f32, max_val: f32) f32 {
-    return (@floatFromInt(f32, xorshift32() & 0xFFFF) / 0x10000) * (max_val - min_val) + min_val;
+    return (@as(f32, @floatFromInt(xorshift32() & 0xFFFF)) / 0x10000) * (max_val - min_val) + min_val;
 }

--- a/src/examples/instancing.zig
+++ b/src/examples/instancing.zig
@@ -184,5 +184,5 @@ fn xorshift32() u32 {
 }
 
 fn rand(min_val: f32, max_val: f32) f32 {
-    return (@intToFloat(f32, xorshift32() & 0xFFFF) / 0x10000) * (max_val - min_val) + min_val;
+    return (@floatFromInt(f32, xorshift32() & 0xFFFF) / 0x10000) * (max_val - min_val) + min_val;
 }

--- a/src/examples/math.zig
+++ b/src/examples/math.zig
@@ -14,30 +14,33 @@ fn radians(deg: f32) f32 {
 }
 
 pub const Vec2 = extern struct {
-    x: f32, y: f32,
+    x: f32,
+    y: f32,
 
     pub fn zero() Vec2 {
-        return Vec2 { .x=0.0, .y=0.0 };
+        return Vec2{ .x = 0.0, .y = 0.0 };
     }
 
     pub fn new(x: f32, y: f32) Vec2 {
-        return Vec2 { .x=x, .y=y };
+        return Vec2{ .x = x, .y = y };
     }
 };
 
 pub const Vec3 = extern struct {
-    x: f32, y: f32, z: f32,
+    x: f32,
+    y: f32,
+    z: f32,
 
     pub fn zero() Vec3 {
-        return Vec3 { .x=0.0, .y=0.0, .z=0.0 };
+        return Vec3{ .x = 0.0, .y = 0.0, .z = 0.0 };
     }
 
     pub fn new(x: f32, y: f32, z: f32) Vec3 {
-        return Vec3 { .x=x, .y=y, .z=z };
+        return Vec3{ .x = x, .y = y, .z = z };
     }
 
     pub fn up() Vec3 {
-        return Vec3 { .x=0.0, .y=1.0, .z=0.0 };
+        return Vec3{ .x = 0.0, .y = 1.0, .z = 0.0 };
     }
 
     pub fn len(v: Vec3) f32 {
@@ -45,49 +48,28 @@ pub const Vec3 = extern struct {
     }
 
     pub fn add(left: Vec3, right: Vec3) Vec3 {
-        return Vec3 {
-            .x = left.x + right.x,
-            .y = left.y + right.y,
-            .z = left.z + right.z
-        };
+        return Vec3{ .x = left.x + right.x, .y = left.y + right.y, .z = left.z + right.z };
     }
 
     pub fn sub(left: Vec3, right: Vec3) Vec3 {
-        return Vec3 {
-            .x = left.x - right.x,
-            .y = left.y - right.y,
-            .z = left.z - right.z
-        };
+        return Vec3{ .x = left.x - right.x, .y = left.y - right.y, .z = left.z - right.z };
     }
 
     pub fn mul(v: Vec3, s: f32) Vec3 {
-        return Vec3 {
-            .x = v.x * s,
-            .y = v.y * s,
-            .z = v.z * s
-        };
+        return Vec3{ .x = v.x * s, .y = v.y * s, .z = v.z * s };
     }
 
     pub fn norm(v: Vec3) Vec3 {
         const l = Vec3.len(v);
         if (l != 0.0) {
-            return Vec3 {
-                .x = v.x / l,
-                .y = v.y / l,
-                .z = v.z / l
-            };
-        }
-        else {
+            return Vec3{ .x = v.x / l, .y = v.y / l, .z = v.z / l };
+        } else {
             return Vec3.zero();
         }
     }
 
     pub fn cross(v0: Vec3, v1: Vec3) Vec3 {
-        return Vec3 {
-            .x = (v0.y * v1.z) - (v0.z * v1.y),
-            .y = (v0.z * v1.x) - (v0.x * v1.z),
-            .z = (v0.x * v1.y) - (v0.y * v1.x)
-        };
+        return Vec3{ .x = (v0.y * v1.z) - (v0.z * v1.y), .y = (v0.z * v1.x) - (v0.x * v1.z), .z = (v0.x * v1.y) - (v0.y * v1.x) };
     }
 
     pub fn dot(v0: Vec3, v1: Vec3) f32 {
@@ -99,37 +81,27 @@ pub const Mat4 = extern struct {
     m: [4][4]f32,
 
     pub fn identity() Mat4 {
-        return Mat4 {
-            .m = [_][4]f32 {
-                .{ 1.0, 0.0, 0.0, 0.0 },
-                .{ 0.0, 1.0, 0.0, 0.0 },
-                .{ 0.0, 0.0, 1.0, 0.0 },
-                .{ 0.0, 0.0, 0.0, 1.0 }
-            },
+        return Mat4{
+            .m = [_][4]f32{ .{ 1.0, 0.0, 0.0, 0.0 }, .{ 0.0, 1.0, 0.0, 0.0 }, .{ 0.0, 0.0, 1.0, 0.0 }, .{ 0.0, 0.0, 0.0, 1.0 } },
         };
     }
 
     pub fn zero() Mat4 {
-        return Mat4 {
-            .m = [_][4]f32 {
-                .{ 0.0, 0.0, 0.0, 0.0 },
-                .{ 0.0, 0.0, 0.0, 0.0 },
-                .{ 0.0, 0.0, 0.0, 0.0 },
-                .{ 0.0, 0.0, 0.0, 0.0 }
-            },
+        return Mat4{
+            .m = [_][4]f32{ .{ 0.0, 0.0, 0.0, 0.0 }, .{ 0.0, 0.0, 0.0, 0.0 }, .{ 0.0, 0.0, 0.0, 0.0 }, .{ 0.0, 0.0, 0.0, 0.0 } },
         };
     }
 
     pub fn mul(left: Mat4, right: Mat4) Mat4 {
         var res = Mat4.zero();
         var col: usize = 0;
-        while (col < 4): (col += 1) {
+        while (col < 4) : (col += 1) {
             var row: usize = 0;
-            while (row < 4): (row += 1) {
+            while (row < 4) : (row += 1) {
                 res.m[col][row] = left.m[0][row] * right.m[col][0] +
-                                  left.m[1][row] * right.m[col][1] +
-                                  left.m[2][row] * right.m[col][2] +
-                                  left.m[3][row] * right.m[col][3];
+                    left.m[1][row] * right.m[col][1] +
+                    left.m[2][row] * right.m[col][2] +
+                    left.m[3][row] * right.m[col][3];
             }
         }
         return res;
@@ -220,15 +192,14 @@ test "Mat4.ident" {
         for (row, 0..) |val, x| {
             if (x == y) {
                 assert(val == 1.0);
-            }
-            else {
+            } else {
                 assert(val == 0.0);
             }
         }
     }
 }
 
-test "Mat4.mul"{
+test "Mat4.mul" {
     const l = Mat4.identity();
     const r = Mat4.identity();
     const m = Mat4.mul(l, r);
@@ -236,8 +207,7 @@ test "Mat4.mul"{
         for (row, 0..) |val, x| {
             if (x == y) {
                 assert(val == 1.0);
-            }
-            else {
+            } else {
                 assert(val == 0.0);
             }
         }
@@ -246,7 +216,7 @@ test "Mat4.mul"{
 
 fn eq(val: f32, cmp: f32) bool {
     const delta: f32 = 0.00001;
-    return (val > (cmp-delta)) and (val < (cmp+delta));
+    return (val > (cmp - delta)) and (val < (cmp + delta));
 }
 
 test "Mat4.persp" {
@@ -274,7 +244,7 @@ test "Mat4.persp" {
 }
 
 test "Mat4.lookat" {
-    const m = Mat4.lookat(.{ .x=0.0, .y=1.5, .z=6.0 }, Vec3.zero(), Vec3.up());
+    const m = Mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 6.0 }, Vec3.zero(), Vec3.up());
 
     assert(eq(m.m[0][0], 1.0));
     assert(eq(m.m[0][1], 0.0));
@@ -298,7 +268,7 @@ test "Mat4.lookat" {
 }
 
 test "Mat4.rotate" {
-    const m = Mat4.rotate(2.0, .{ .x=0.0, .y=1.0, .z=0.0 });
+    const m = Mat4.rotate(2.0, .{ .x = 0.0, .y = 1.0, .z = 0.0 });
 
     assert(eq(m.m[0][0], 0.99939));
     assert(eq(m.m[0][1], 0.0));
@@ -320,6 +290,3 @@ test "Mat4.rotate" {
     assert(eq(m.m[3][2], 0.0));
     assert(eq(m.m[3][3], 1.0));
 }
-
-
-

--- a/src/examples/mrt.zig
+++ b/src/examples/mrt.zig
@@ -9,16 +9,16 @@
 //  in GL vs D3D vs Metal. We don't care about those differences in this sample
 //  (using the sokol shader compiler allows to easily 'normalize' those differences.
 //------------------------------------------------------------------------------
-const math  = @import("std").math;
+const math = @import("std").math;
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const vec2  = @import("math.zig").Vec2;
-const vec3  = @import("math.zig").Vec3;
-const mat4  = @import("math.zig").Mat4;
-const shd   = @import("shaders/mrt.glsl.zig");
+const vec2 = @import("math.zig").Vec2;
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/mrt.glsl.zig");
 
 const offscreen_sample_count = 4;
 
@@ -43,7 +43,7 @@ const state = struct {
     };
     var rx: f32 = 0.0;
     var ry: f32 = 0.0;
-    const view: mat4 = mat4.lookat(.{ .x=0.0, .y=1.5, .z=6.0 }, vec3.zero(), vec3.up());
+    const view: mat4 = mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 6.0 }, vec3.zero(), vec3.up());
 };
 
 export fn init() void {
@@ -54,13 +54,13 @@ export fn init() void {
 
     // setup pass action for default render pass
     state.default.pass_action.colors[0] = .{ .action = .DONTCARE };
-    state.default.pass_action.depth     = .{ .action = .DONTCARE };
-    state.default.pass_action.stencil   = .{ .action = .DONTCARE };
+    state.default.pass_action.depth = .{ .action = .DONTCARE };
+    state.default.pass_action.stencil = .{ .action = .DONTCARE };
 
     // set pass action for offscreen render pass
-    state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0.25, .g=0, .b=0, .a=1 } };
-    state.offscreen.pass_action.colors[1] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0.25, .b=0, .a=1 } };
-    state.offscreen.pass_action.colors[2] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0, .b=0.25, .a=1 } };
+    state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.25, .g = 0, .b = 0, .a = 1 } };
+    state.offscreen.pass_action.colors[1] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0.25, .b = 0, .a = 1 } };
+    state.offscreen.pass_action.colors[2] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0.25, .a = 1 } };
 
     // setup the offscreen render pass and render target images,
     // this will also be called when the window resizes
@@ -70,50 +70,40 @@ export fn init() void {
     const cube_vbuf = sg.makeBuffer(.{
         .data = sg.asRange(&[_]f32{
             // positions        brightness
-            -1.0, -1.0, -1.0,   1.0,
-             1.0, -1.0, -1.0,   1.0,
-             1.0,  1.0, -1.0,   1.0,
-            -1.0,  1.0, -1.0,   1.0,
+            -1.0, -1.0, -1.0, 1.0,
+            1.0,  -1.0, -1.0, 1.0,
+            1.0,  1.0,  -1.0, 1.0,
+            -1.0, 1.0,  -1.0, 1.0,
 
-            -1.0, -1.0,  1.0,   0.8,
-             1.0, -1.0,  1.0,   0.8,
-             1.0,  1.0,  1.0,   0.8,
-            -1.0,  1.0,  1.0,   0.8,
+            -1.0, -1.0, 1.0,  0.8,
+            1.0,  -1.0, 1.0,  0.8,
+            1.0,  1.0,  1.0,  0.8,
+            -1.0, 1.0,  1.0,  0.8,
 
-            -1.0, -1.0, -1.0,   0.6,
-            -1.0,  1.0, -1.0,   0.6,
-            -1.0,  1.0,  1.0,   0.6,
-            -1.0, -1.0,  1.0,   0.6,
+            -1.0, -1.0, -1.0, 0.6,
+            -1.0, 1.0,  -1.0, 0.6,
+            -1.0, 1.0,  1.0,  0.6,
+            -1.0, -1.0, 1.0,  0.6,
 
-             1.0, -1.0, -1.0,   0.4,
-             1.0,  1.0, -1.0,   0.4,
-             1.0,  1.0,  1.0,   0.4,
-             1.0, -1.0,  1.0,   0.4,
+            1.0,  -1.0, -1.0, 0.4,
+            1.0,  1.0,  -1.0, 0.4,
+            1.0,  1.0,  1.0,  0.4,
+            1.0,  -1.0, 1.0,  0.4,
 
-            -1.0, -1.0, -1.0,   0.5,
-            -1.0, -1.0,  1.0,   0.5,
-             1.0, -1.0,  1.0,   0.5,
-             1.0, -1.0, -1.0,   0.5,
+            -1.0, -1.0, -1.0, 0.5,
+            -1.0, -1.0, 1.0,  0.5,
+            1.0,  -1.0, 1.0,  0.5,
+            1.0,  -1.0, -1.0, 0.5,
 
-            -1.0,  1.0, -1.0,   0.7,
-            -1.0,  1.0,  1.0,   0.7,
-             1.0,  1.0,  1.0,   0.7,
-             1.0,  1.0, -1.0,   0.7
-        })
+            -1.0, 1.0,  -1.0, 0.7,
+            -1.0, 1.0,  1.0,  0.7,
+            1.0,  1.0,  1.0,  0.7,
+            1.0,  1.0,  -1.0, 0.7,
+        }),
     });
 
     // index buffer for a cube
-    const cube_ibuf = sg.makeBuffer(.{
-        .type = .INDEXBUFFER,
-        .data = sg.asRange(&[_]u16{
-            0, 1, 2,  0, 2, 3,
-            6, 5, 4,  7, 6, 4,
-            8, 9, 10,  8, 10, 11,
-            14, 13, 12,  15, 14, 12,
-            16, 17, 18,  16, 18, 19,
-            22, 21, 20,  23, 22, 20
-        })
-    });
+    const cube_ibuf = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
 
     // resource bindings for offscreen rendering
     state.offscreen.bind.vertex_buffers[0] = cube_vbuf;
@@ -137,9 +127,7 @@ export fn init() void {
     state.offscreen.pip = sg.makePipeline(offscreen_pip_desc);
 
     // a vertex buffer to render a fullscreen quad
-    const quad_vbuf = sg.makeBuffer(.{
-        .data = sg.asRange(&[_]f32 { 0.0, 0.0,  1.0, 0.0,  0.0, 1.0,  1.0, 1.0 })
-    });
+    const quad_vbuf = sg.makeBuffer(.{ .data = sg.asRange(&[_]f32{ 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0 }) });
 
     // shader and pipeline object to render a fullscreen quad which composes
     // the 3 offscreen render targets into the default framebuffer
@@ -153,7 +141,7 @@ export fn init() void {
     // resource bindings to render the fullscreen quad (composed from the
     // offscreen render target textures
     state.fsq.bind.vertex_buffers[0] = quad_vbuf;
-    inline for (.{0, 1, 2}) |i| {
+    inline for (.{ 0, 1, 2 }) |i| {
         state.fsq.bind.fs_images[i] = state.offscreen.pass_desc.color_attachments[i].image;
     }
 
@@ -171,18 +159,13 @@ export fn init() void {
 }
 
 export fn frame() void {
-
-    const dt = @floatCast(f32, sapp.frameDuration()) * 60.0;
+    const dt = @as(f32, @floatCast(sapp.frameDuration())) * 60.0;
     state.rx += 1.0 * dt;
     state.ry += 2.0 * dt;
 
     // compute shader uniform data
-    const offscreen_params: shd.OffscreenParams = .{
-        .mvp = computeMVP(state.rx, state.ry)
-    };
-    const fsq_params: shd.FsqParams = .{
-        .offset = .{ .x = math.sin(state.rx * 0.01) * 0.1, .y = math.cos(state.ry * 0.01) * 0.1 }
-    };
+    const offscreen_params: shd.OffscreenParams = .{ .mvp = computeMVP(state.rx, state.ry) };
+    const fsq_params: shd.FsqParams = .{ .offset = .{ .x = math.sin(state.rx * 0.01) * 0.1, .y = math.cos(state.ry * 0.01) * 0.1 } };
 
     // render cube into MRT offscreen render targets
     sg.beginPass(state.offscreen.pass, state.offscreen.pass_action);
@@ -200,7 +183,7 @@ export fn frame() void {
     sg.applyUniforms(.VS, shd.SLOT_fsq_params, sg.asRange(&fsq_params));
     sg.draw(0, 4, 1);
     sg.applyPipeline(state.dbg.pip);
-    inline for (.{0, 1, 2 }) |i| {
+    inline for (.{ 0, 1, 2 }) |i| {
         sg.applyViewport(i * 100, 0, 100, 100, false);
         state.dbg.bind.fs_images[0] = state.offscreen.pass_desc.color_attachments[i].image;
         sg.applyBindings(state.dbg.bind);
@@ -237,8 +220,8 @@ pub fn main() void {
 
 // compute model-view-projection matrix
 fn computeMVP(rx: f32, ry: f32) mat4 {
-    const rxm = mat4.rotate(rx, .{ .x=1.0, .y=0.0, .z=0.0 });
-    const rym = mat4.rotate(ry, .{ .x=0.0, .y=1.0, .z=0.0 });
+    const rxm = mat4.rotate(rx, .{ .x = 1.0, .y = 0.0, .z = 0.0 });
+    const rym = mat4.rotate(ry, .{ .x = 0.0, .y = 1.0, .z = 0.0 });
     const model = mat4.mul(rxm, rym);
     const aspect = sapp.widthf() / sapp.heightf();
     const proj = mat4.persp(60.0, aspect, 0.01, 10.0);

--- a/src/examples/mrt.zig
+++ b/src/examples/mrt.zig
@@ -103,7 +103,17 @@ export fn init() void {
     });
 
     // index buffer for a cube
-    const cube_ibuf = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
+    const cube_ibuf = sg.makeBuffer(.{
+        .type = .INDEXBUFFER,
+        .data = sg.asRange(&[_]u16{
+            0,  1,  2,  0,  2,  3,
+            6,  5,  4,  7,  6,  4,
+            8,  9,  10, 8,  10, 11,
+            14, 13, 12, 15, 14, 12,
+            16, 17, 18, 16, 18, 19,
+            22, 21, 20, 23, 22, 20,
+        }),
+    });
 
     // resource bindings for offscreen rendering
     state.offscreen.bind.vertex_buffers[0] = cube_vbuf;
@@ -164,8 +174,13 @@ export fn frame() void {
     state.ry += 2.0 * dt;
 
     // compute shader uniform data
-    const offscreen_params: shd.OffscreenParams = .{ .mvp = computeMVP(state.rx, state.ry) };
-    const fsq_params: shd.FsqParams = .{ .offset = .{ .x = math.sin(state.rx * 0.01) * 0.1, .y = math.cos(state.ry * 0.01) * 0.1 } };
+    const offscreen_params: shd.OffscreenParams = .{
+        .mvp = computeMVP(state.rx, state.ry),
+    };
+    const fsq_params: shd.FsqParams = .{ .offset = .{
+        .x = math.sin(state.rx * 0.01) * 0.1,
+        .y = math.cos(state.ry * 0.01) * 0.1,
+    } };
 
     // render cube into MRT offscreen render targets
     sg.beginPass(state.offscreen.pass, state.offscreen.pass_action);

--- a/src/examples/noninterleaved.zig
+++ b/src/examples/noninterleaved.zig
@@ -8,13 +8,13 @@
 //  several related vertex components interleaved in the same chunk.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const vec3  = @import("math.zig").Vec3;
-const mat4  = @import("math.zig").Mat4;
-const shd   = @import("shaders/noninterleaved.glsl.zig");
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/noninterleaved.glsl.zig");
 
 const state = struct {
     var rx: f32 = 0.0;
@@ -23,7 +23,7 @@ const state = struct {
     var bind: sg.Bindings = .{};
     var pass_action: sg.PassAction = .{};
     // the view matrix doesn't change
-    const view: mat4 = mat4.lookat(.{ .x=0.0, .y=1.5, .z=6.0 }, vec3.zero(), vec3.up());
+    const view: mat4 = mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 6.0 }, vec3.zero(), vec3.up());
 };
 
 export fn init() void {
@@ -36,45 +36,32 @@ export fn init() void {
     const vbuf = sg.makeBuffer(.{
         .data = sg.asRange(&[_]f32{
             // positions
-            -1.0, -1.0, -1.0,   1.0, -1.0, -1.0,   1.0,  1.0, -1.0,  -1.0,  1.0, -1.0,
-            -1.0, -1.0,  1.0,   1.0, -1.0,  1.0,   1.0,  1.0,  1.0,  -1.0,  1.0,  1.0,
-            -1.0, -1.0, -1.0,  -1.0,  1.0, -1.0,  -1.0,  1.0,  1.0,  -1.0, -1.0,  1.0,
-             1.0, -1.0, -1.0,   1.0,  1.0, -1.0,   1.0,  1.0,  1.0,   1.0, -1.0,  1.0,
-            -1.0, -1.0, -1.0,  -1.0, -1.0,  1.0,   1.0, -1.0,  1.0,   1.0, -1.0, -1.0,
-            -1.0,  1.0, -1.0,  -1.0,  1.0,  1.0,   1.0,  1.0,  1.0,   1.0,  1.0, -1.0,
+            -1.0, -1.0, -1.0, 1.0,  -1.0, -1.0, 1.0,  1.0,  -1.0, -1.0, 1.0,  -1.0,
+            -1.0, -1.0, 1.0,  1.0,  -1.0, 1.0,  1.0,  1.0,  1.0,  -1.0, 1.0,  1.0,
+            -1.0, -1.0, -1.0, -1.0, 1.0,  -1.0, -1.0, 1.0,  1.0,  -1.0, -1.0, 1.0,
+            1.0,  -1.0, -1.0, 1.0,  1.0,  -1.0, 1.0,  1.0,  1.0,  1.0,  -1.0, 1.0,
+            -1.0, -1.0, -1.0, -1.0, -1.0, 1.0,  1.0,  -1.0, 1.0,  1.0,  -1.0, -1.0,
+            -1.0, 1.0,  -1.0, -1.0, 1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  -1.0,
             // colors
-            1.0, 0.5, 0.0, 1.0,  1.0, 0.5, 0.0, 1.0,  1.0, 0.5, 0.0, 1.0,  1.0, 0.5, 0.0, 1.0,
-            0.5, 1.0, 0.0, 1.0,  0.5, 1.0, 0.0, 1.0,  0.5, 1.0, 0.0, 1.0,  0.5, 1.0, 0.0, 1.0,
-            0.5, 0.0, 1.0, 1.0,  0.5, 0.0, 1.0, 1.0,  0.5, 0.0, 1.0, 1.0,  0.5, 0.0, 1.0, 1.0,
-            1.0, 0.5, 1.0, 1.0,  1.0, 0.5, 1.0, 1.0,  1.0, 0.5, 1.0, 1.0,  1.0, 0.5, 1.0, 1.0,
-            0.5, 1.0, 1.0, 1.0,  0.5, 1.0, 1.0, 1.0,  0.5, 1.0, 1.0, 1.0,  0.5, 1.0, 1.0, 1.0,
-            1.0, 1.0, 0.5, 1.0,  1.0, 1.0, 0.5, 1.0,  1.0, 1.0, 0.5, 1.0,  1.0, 1.0, 0.5, 1.0,
-        })
+            1.0,  0.5,  0.0,  1.0,  1.0,  0.5,  0.0,  1.0,  1.0,  0.5,  0.0,  1.0,
+            1.0,  0.5,  0.0,  1.0,  0.5,  1.0,  0.0,  1.0,  0.5,  1.0,  0.0,  1.0,
+            0.5,  1.0,  0.0,  1.0,  0.5,  1.0,  0.0,  1.0,  0.5,  0.0,  1.0,  1.0,
+            0.5,  0.0,  1.0,  1.0,  0.5,  0.0,  1.0,  1.0,  0.5,  0.0,  1.0,  1.0,
+            1.0,  0.5,  1.0,  1.0,  1.0,  0.5,  1.0,  1.0,  1.0,  0.5,  1.0,  1.0,
+            1.0,  0.5,  1.0,  1.0,  0.5,  1.0,  1.0,  1.0,  0.5,  1.0,  1.0,  1.0,
+            0.5,  1.0,  1.0,  1.0,  0.5,  1.0,  1.0,  1.0,  1.0,  1.0,  0.5,  1.0,
+            1.0,  1.0,  0.5,  1.0,  1.0,  1.0,  0.5,  1.0,  1.0,  1.0,  0.5,  1.0,
+        }),
     });
 
     // cube index buffer
-    const ibuf = sg.makeBuffer(.{
-        .type = .INDEXBUFFER,
-        .data = sg.asRange(&[_]u16{
-            0, 1, 2,  0, 2, 3,
-            6, 5, 4,  7, 6, 4,
-            8, 9, 10,  8, 10, 11,
-            14, 13, 12,  15, 14, 12,
-            16, 17, 18,  16, 18, 19,
-            22, 21, 20,  23, 22, 20
-        })
-    });
+    const ibuf = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
 
     // shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{
-        .shader = sg.makeShader(shd.noninterleavedShaderDesc(sg.queryBackend())),
-        .index_type = .UINT16,
-        .cull_mode = .BACK,
-        .depth = .{
-            .compare = .LESS_EQUAL,
-            .write_enabled = true,
-        }
-    };
+    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.noninterleavedShaderDesc(sg.queryBackend())), .index_type = .UINT16, .cull_mode = .BACK, .depth = .{
+        .compare = .LESS_EQUAL,
+        .write_enabled = true,
+    } };
     // NOTE how the vertex components are pulled from different buffer bind slots
     pip_desc.layout.attrs[shd.ATTR_vs_position] = .{ .format = .FLOAT3, .buffer_index = 0 };
     pip_desc.layout.attrs[shd.ATTR_vs_color0] = .{ .format = .FLOAT4, .buffer_index = 1 };
@@ -93,7 +80,7 @@ export fn init() void {
 }
 
 export fn frame() void {
-    const dt = @floatCast(f32, sapp.frameDuration() * 60);
+    const dt = @as(f32, @floatCast(sapp.frameDuration() * 60));
     state.rx += 1.0 * dt;
     state.ry += 2.0 * dt;
     const vs_params = computeVsParams(state.rx, state.ry);
@@ -112,26 +99,14 @@ export fn cleanup() void {
 }
 
 pub fn main() void {
-    sapp.run(.{
-        .init_cb = init,
-        .frame_cb = frame,
-        .cleanup_cb = cleanup,
-        .width = 800,
-        .height = 600,
-        .sample_count = 4,
-        .icon = .{ .sokol_default = true },
-        .logger = .{ .func = slog.func },
-        .window_title = "noninterleaved.zig"
-    });
+    sapp.run(.{ .init_cb = init, .frame_cb = frame, .cleanup_cb = cleanup, .width = 800, .height = 600, .sample_count = 4, .icon = .{ .sokol_default = true }, .logger = .{ .func = slog.func }, .window_title = "noninterleaved.zig" });
 }
 
 fn computeVsParams(rx: f32, ry: f32) shd.VsParams {
-    const rxm = mat4.rotate(rx, .{ .x=1.0, .y=0.0, .z=0.0 });
-    const rym = mat4.rotate(ry, .{ .x=0.0, .y=1.0, .z=0.0 });
+    const rxm = mat4.rotate(rx, .{ .x = 1.0, .y = 0.0, .z = 0.0 });
+    const rym = mat4.rotate(ry, .{ .x = 0.0, .y = 1.0, .z = 0.0 });
     const model = mat4.mul(rxm, rym);
     const aspect = sapp.widthf() / sapp.heightf();
     const proj = mat4.persp(60.0, aspect, 0.01, 10.0);
-    return shd.VsParams {
-        .mvp = mat4.mul(mat4.mul(proj, state.view), model)
-    };
+    return shd.VsParams{ .mvp = mat4.mul(mat4.mul(proj, state.view), model) };
 }

--- a/src/examples/noninterleaved.zig
+++ b/src/examples/noninterleaved.zig
@@ -55,13 +55,28 @@ export fn init() void {
     });
 
     // cube index buffer
-    const ibuf = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
+    const ibuf = sg.makeBuffer(.{
+        .type = .INDEXBUFFER,
+        .data = sg.asRange(&[_]u16{
+            0,  1,  2,  0,  2,  3,
+            6,  5,  4,  7,  6,  4,
+            8,  9,  10, 8,  10, 11,
+            14, 13, 12, 15, 14, 12,
+            16, 17, 18, 16, 18, 19,
+            22, 21, 20, 23, 22, 20,
+        }),
+    });
 
     // shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.noninterleavedShaderDesc(sg.queryBackend())), .index_type = .UINT16, .cull_mode = .BACK, .depth = .{
-        .compare = .LESS_EQUAL,
-        .write_enabled = true,
-    } };
+    var pip_desc: sg.PipelineDesc = .{
+        .shader = sg.makeShader(shd.noninterleavedShaderDesc(sg.queryBackend())),
+        .index_type = .UINT16,
+        .cull_mode = .BACK,
+        .depth = .{
+            .compare = .LESS_EQUAL,
+            .write_enabled = true,
+        },
+    };
     // NOTE how the vertex components are pulled from different buffer bind slots
     pip_desc.layout.attrs[shd.ATTR_vs_position] = .{ .format = .FLOAT3, .buffer_index = 0 };
     pip_desc.layout.attrs[shd.ATTR_vs_color0] = .{ .format = .FLOAT4, .buffer_index = 1 };
@@ -99,7 +114,17 @@ export fn cleanup() void {
 }
 
 pub fn main() void {
-    sapp.run(.{ .init_cb = init, .frame_cb = frame, .cleanup_cb = cleanup, .width = 800, .height = 600, .sample_count = 4, .icon = .{ .sokol_default = true }, .logger = .{ .func = slog.func }, .window_title = "noninterleaved.zig" });
+    sapp.run(.{
+        .init_cb = init,
+        .frame_cb = frame,
+        .cleanup_cb = cleanup,
+        .width = 800,
+        .height = 600,
+        .sample_count = 4,
+        .icon = .{ .sokol_default = true },
+        .logger = .{ .func = slog.func },
+        .window_title = "noninterleaved.zig",
+    });
 }
 
 fn computeVsParams(rx: f32, ry: f32) shd.VsParams {

--- a/src/examples/offscreen.zig
+++ b/src/examples/offscreen.zig
@@ -4,15 +4,15 @@
 //  Render to an offscreen rendertarget texture, and use this texture
 //  for rendering to the display.
 //------------------------------------------------------------------------------
-const sokol  = @import("sokol");
-const slog   = sokol.log;
-const sg     = sokol.gfx;
-const sapp   = sokol.app;
-const sgapp  = sokol.app_gfx_glue;
+const sokol = @import("sokol");
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
+const sgapp = sokol.app_gfx_glue;
 const sshape = sokol.shape;
-const vec3   = @import("math.zig").Vec3;
-const mat4   = @import("math.zig").Mat4;
-const shd    = @import("shaders/offscreen.glsl.zig");
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/offscreen.glsl.zig");
 
 const offscreen_sample_count = 4;
 
@@ -41,23 +41,13 @@ export fn init() void {
     });
 
     // default pass action: clear to blue-ish
-    state.default.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0.25, .g=0.45, .b=0.65, .a=1.0 } };
+    state.default.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.25, .g = 0.45, .b = 0.65, .a = 1.0 } };
 
     // offscreen pass action: clear to black
-    state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0.25, .g=0.25, .b=0.25, .a=1.0 } };
+    state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.25, .g = 0.25, .b = 0.25, .a = 1.0 } };
 
     // a render pass with one color- and one depth-attachment image
-    var img_desc: sg.ImageDesc = .{
-        .render_target = true,
-        .width = 256,
-        .height = 256,
-        .pixel_format = .RGBA8,
-        .min_filter = .LINEAR,
-        .mag_filter = .LINEAR,
-        .wrap_u = .REPEAT,
-        .wrap_v = .REPEAT,
-        .sample_count = offscreen_sample_count
-    };
+    var img_desc: sg.ImageDesc = .{ .render_target = true, .width = 256, .height = 256, .pixel_format = .RGBA8, .min_filter = .LINEAR, .mag_filter = .LINEAR, .wrap_u = .REPEAT, .wrap_v = .REPEAT, .sample_count = offscreen_sample_count };
     const color_img = sg.makeImage(img_desc);
     img_desc.pixel_format = .DEPTH;
     const depth_img = sg.makeImage(img_desc);
@@ -73,14 +63,9 @@ export fn init() void {
     var indices: [24000]u16 = undefined;
     var buf: sshape.Buffer = .{
         .vertices = .{ .buffer = sshape.asRange(&vertices) },
-        .indices  = .{ .buffer = sshape.asRange(&indices) },
+        .indices = .{ .buffer = sshape.asRange(&indices) },
     };
-    buf = sshape.buildTorus(buf, .{
-        .radius = 0.5,
-        .ring_radius = 0.3,
-        .sides = 20,
-        .rings = 36
-    });
+    buf = sshape.buildTorus(buf, .{ .radius = 0.5, .ring_radius = 0.3, .sides = 20, .rings = 36 });
     state.donut = sshape.elementRange(buf);
     buf = sshape.buildSphere(buf, .{
         .radius = 0.5,
@@ -137,8 +122,7 @@ export fn init() void {
 }
 
 export fn frame() void {
-
-    const dt = @floatCast(f32, sapp.frameDuration()) * 60.0;
+    const dt = @as(f32, @floatCast(sapp.frameDuration())) * 60.0;
     state.rx += 1 * dt;
     state.ry += 2 * dt;
     const aspect = sapp.widthf() / sapp.heightf();
@@ -156,7 +140,7 @@ export fn frame() void {
     sg.beginDefaultPass(state.default.pass_action, sapp.width(), sapp.height());
     sg.applyPipeline(state.default.pip);
     sg.applyBindings(state.default.bind);
-    sg.applyUniforms(.VS, 0, sg.asRange(&computeVsParams(-state.rx*0.25, state.ry*0.25, aspect, 2)));
+    sg.applyUniforms(.VS, 0, sg.asRange(&computeVsParams(-state.rx * 0.25, state.ry * 0.25, aspect, 2)));
     sg.draw(state.sphere.base_element, state.sphere.num_elements, 1);
     sg.endPass();
 
@@ -183,12 +167,10 @@ pub fn main() void {
 
 fn computeVsParams(rx: f32, ry: f32, aspect: f32, eye_dist: f32) shd.VsParams {
     const proj = mat4.persp(45, aspect, 0.01, 10);
-    const view = mat4.lookat(.{ .x=0, .y=0, .z=eye_dist}, vec3.zero(), vec3.up());
+    const view = mat4.lookat(.{ .x = 0, .y = 0, .z = eye_dist }, vec3.zero(), vec3.up());
     const view_proj = mat4.mul(proj, view);
-    const rxm = mat4.rotate(rx, .{ .x=1, .y=0, .z=0 });
-    const rym = mat4.rotate(ry, .{ .x=0, .y=1, .z=0 });
+    const rxm = mat4.rotate(rx, .{ .x = 1, .y = 0, .z = 0 });
+    const rym = mat4.rotate(ry, .{ .x = 0, .y = 1, .z = 0 });
     const model = mat4.mul(rxm, rym);
-    return shd.VsParams {
-        .mvp = mat4.mul(view_proj, model)
-    };
+    return shd.VsParams{ .mvp = mat4.mul(view_proj, model) };
 }

--- a/src/examples/offscreen.zig
+++ b/src/examples/offscreen.zig
@@ -47,7 +47,17 @@ export fn init() void {
     state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.25, .g = 0.25, .b = 0.25, .a = 1.0 } };
 
     // a render pass with one color- and one depth-attachment image
-    var img_desc: sg.ImageDesc = .{ .render_target = true, .width = 256, .height = 256, .pixel_format = .RGBA8, .min_filter = .LINEAR, .mag_filter = .LINEAR, .wrap_u = .REPEAT, .wrap_v = .REPEAT, .sample_count = offscreen_sample_count };
+    var img_desc: sg.ImageDesc = .{
+        .render_target = true,
+        .width = 256,
+        .height = 256,
+        .pixel_format = .RGBA8,
+        .min_filter = .LINEAR,
+        .mag_filter = .LINEAR,
+        .wrap_u = .REPEAT,
+        .wrap_v = .REPEAT,
+        .sample_count = offscreen_sample_count,
+    };
     const color_img = sg.makeImage(img_desc);
     img_desc.pixel_format = .DEPTH;
     const depth_img = sg.makeImage(img_desc);
@@ -65,7 +75,12 @@ export fn init() void {
         .vertices = .{ .buffer = sshape.asRange(&vertices) },
         .indices = .{ .buffer = sshape.asRange(&indices) },
     };
-    buf = sshape.buildTorus(buf, .{ .radius = 0.5, .ring_radius = 0.3, .sides = 20, .rings = 36 });
+    buf = sshape.buildTorus(buf, .{
+        .radius = 0.5,
+        .ring_radius = 0.3,
+        .sides = 20,
+        .rings = 36,
+    });
     state.donut = sshape.elementRange(buf);
     buf = sshape.buildSphere(buf, .{
         .radius = 0.5,

--- a/src/examples/quad.zig
+++ b/src/examples/quad.zig
@@ -4,11 +4,11 @@
 //  Simple 2D rendering with vertex- and index-buffer.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const shd   = @import("shaders/quad.glsl.zig");
+const shd = @import("shaders/quad.glsl.zig");
 
 const state = struct {
     var bind: sg.Bindings = .{};
@@ -26,18 +26,15 @@ export fn init() void {
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
         .data = sg.asRange(&[_]f32{
             // positions      colors
-            -0.5,  0.5, 0.5,  1.0, 0.0, 0.0, 1.0,
-             0.5,  0.5, 0.5,  0.0, 1.0, 0.0, 1.0,
-             0.5, -0.5, 0.5,  0.0, 0.0, 1.0, 1.0,
-            -0.5, -0.5, 0.5,  1.0, 1.0, 0.0, 1.0
-        })
+            -0.5, 0.5,  0.5, 1.0, 0.0, 0.0, 1.0,
+            0.5,  0.5,  0.5, 0.0, 1.0, 0.0, 1.0,
+            0.5,  -0.5, 0.5, 0.0, 0.0, 1.0, 1.0,
+            -0.5, -0.5, 0.5, 1.0, 1.0, 0.0, 1.0,
+        }),
     });
 
     // an index buffer
-    state.bind.index_buffer = sg.makeBuffer(.{
-        .type = .INDEXBUFFER,
-        .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3 })
-    });
+    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3 }) });
 
     // a shader and pipeline state object
     var pip_desc: sg.PipelineDesc = .{
@@ -49,7 +46,7 @@ export fn init() void {
     state.pip = sg.makePipeline(pip_desc);
 
     // clear to black
-    state.pass_action.colors[0] = .{ .action=.CLEAR, .value=.{ .r=0, .g=0, .b=0, .a=1 } };
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0, .a = 1 } };
 }
 
 export fn frame() void {

--- a/src/examples/saudio.zig
+++ b/src/examples/saudio.zig
@@ -2,12 +2,12 @@
 //  saudio.zig
 //  Test sokol-audio zig bindings
 //------------------------------------------------------------------------------
-const sokol  = @import("sokol");
-const slog   = sokol.log;
-const sg     = sokol.gfx;
-const sapp   = sokol.app;
+const sokol = @import("sokol");
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const saudio = sokol.audio;
-const sgapp  = sokol.app_gfx_glue;
+const sgapp = sokol.app_gfx_glue;
 
 const NumSamples = 32;
 
@@ -26,13 +26,17 @@ export fn init() void {
     saudio.setup(.{
         .logger = .{ .func = slog.func },
     });
-    state.pass_action.colors[0] = .{ .action=.CLEAR, .value = .{ .r=1, .g=0.5, .b=0, .a=1 }};
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 1, .g = 0.5, .b = 0, .a = 1 } };
 }
 
 export fn frame() void {
     const num_frames = saudio.expect();
     var i: i32 = 0;
-    while (i < num_frames): ({ i += 1; state.even_odd += 1; state.sample_pos += 1; }) {
+    while (i < num_frames) : ({
+        i += 1;
+        state.even_odd += 1;
+        state.sample_pos += 1;
+    }) {
         if (state.sample_pos == NumSamples) {
             state.sample_pos = 0;
             _ = saudio.push(&(state.samples[0]), NumSamples);

--- a/src/examples/sgl-context.zig
+++ b/src/examples/sgl-context.zig
@@ -5,12 +5,12 @@
 //  using contexts.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const sgl   = sokol.gl;
-const math  = @import("std").math;
+const sgl = sokol.gl;
+const math = @import("std").math;
 
 const state = struct {
     const offscreen = struct {
@@ -49,9 +49,7 @@ export fn init() void {
     });
 
     // initialize a pass action struct for the default pass to clear to a light-blue color
-    state.display.pass_action.colors[0] = .{
-        .action = .CLEAR, .value = .{ .r=0.5, .g=0.7, .b=1, .a=1 }
-    };
+    state.display.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.5, .g = 0.7, .b = 1, .a = 1 } };
 
     // create a sokol-gl pipeline object for 3D rendering into the default pass
     state.display.sgl_pip = sgl.contextMakePipeline(sgl.defaultContext(), .{
@@ -89,11 +87,11 @@ export fn init() void {
     pass_desc.color_attachments[0].image = state.offscreen.img;
     state.offscreen.pass = sg.makePass(pass_desc);
 
-    state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0, .b=0, .a=1 } };
+    state.offscreen.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0, .a = 1 } };
 }
 
 export fn frame() void {
-    const a = sgl.asRadians(@floatFromInt(f32, sapp.frameCount()));
+    const a = sgl.asRadians(@as(f32, @floatFromInt(sapp.frameCount())));
 
     // draw a rotating quad into the offscreen render target texture
     sgl.setContext(state.offscreen.sgl_ctx);
@@ -109,8 +107,12 @@ export fn frame() void {
     sgl.texture(state.offscreen.img);
     sgl.loadPipeline(state.display.sgl_pip);
     sgl.matrixModeProjection();
-    sgl.perspective(sgl.asRadians(45.0), sapp.widthf()/sapp.heightf(), 0.1, 100.0);
-    const eye = .{ math.sin(a) * 6.0, math.sin(a) * 3.0, math.cos(a) * 6.0, };
+    sgl.perspective(sgl.asRadians(45.0), sapp.widthf() / sapp.heightf(), 0.1, 100.0);
+    const eye = .{
+        math.sin(a) * 6.0,
+        math.sin(a) * 3.0,
+        math.cos(a) * 6.0,
+    };
     sgl.matrixModeModelview();
     sgl.lookat(eye[0], eye[1], eye[2], 0, 0, 0, 0, 1, 0);
     draw_cube();
@@ -146,38 +148,38 @@ pub fn main() void {
 
 fn draw_quad() void {
     sgl.beginQuads();
-    sgl.v2fC3b( 0.0, -1.0, 255, 0, 0);
-    sgl.v2fC3b( 1.0,  0.0, 0, 0, 255);
-    sgl.v2fC3b( 0.0,  1.0, 0, 255, 255);
-    sgl.v2fC3b(-1.0,  0.0, 0, 255, 0);
+    sgl.v2fC3b(0.0, -1.0, 255, 0, 0);
+    sgl.v2fC3b(1.0, 0.0, 0, 0, 255);
+    sgl.v2fC3b(0.0, 1.0, 0, 255, 255);
+    sgl.v2fC3b(-1.0, 0.0, 0, 255, 0);
     sgl.end();
 }
 
 fn draw_cube() void {
     sgl.beginQuads();
-    sgl.v3fT2f(-1.0,  1.0, -1.0, 0.0, 1.0);
-    sgl.v3fT2f( 1.0,  1.0, -1.0, 1.0, 1.0);
-    sgl.v3fT2f( 1.0, -1.0, -1.0, 1.0, 0.0);
+    sgl.v3fT2f(-1.0, 1.0, -1.0, 0.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, -1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, -1.0, 1.0, 0.0);
     sgl.v3fT2f(-1.0, -1.0, -1.0, 0.0, 0.0);
-    sgl.v3fT2f(-1.0, -1.0,  1.0, 0.0, 1.0);
-    sgl.v3fT2f( 1.0, -1.0,  1.0, 1.0, 1.0);
-    sgl.v3fT2f( 1.0,  1.0,  1.0, 1.0, 0.0);
-    sgl.v3fT2f(-1.0,  1.0,  1.0, 0.0, 0.0);
-    sgl.v3fT2f(-1.0, -1.0,  1.0, 0.0, 1.0);
-    sgl.v3fT2f(-1.0,  1.0,  1.0, 1.0, 1.0);
-    sgl.v3fT2f(-1.0,  1.0, -1.0, 1.0, 0.0);
+    sgl.v3fT2f(-1.0, -1.0, 1.0, 0.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, 1.0, 1.0, 0.0);
+    sgl.v3fT2f(-1.0, 1.0, 1.0, 0.0, 0.0);
+    sgl.v3fT2f(-1.0, -1.0, 1.0, 0.0, 1.0);
+    sgl.v3fT2f(-1.0, 1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(-1.0, 1.0, -1.0, 1.0, 0.0);
     sgl.v3fT2f(-1.0, -1.0, -1.0, 0.0, 0.0);
-    sgl.v3fT2f( 1.0, -1.0,  1.0, 0.0, 1.0);
-    sgl.v3fT2f( 1.0, -1.0, -1.0, 1.0, 1.0);
-    sgl.v3fT2f( 1.0,  1.0, -1.0, 1.0, 0.0);
-    sgl.v3fT2f( 1.0,  1.0,  1.0, 0.0, 0.0);
-    sgl.v3fT2f( 1.0, -1.0, -1.0, 0.0, 1.0);
-    sgl.v3fT2f( 1.0, -1.0,  1.0, 1.0, 1.0);
-    sgl.v3fT2f(-1.0, -1.0,  1.0, 1.0, 0.0);
+    sgl.v3fT2f(1.0, -1.0, 1.0, 0.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, -1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, -1.0, 1.0, 0.0);
+    sgl.v3fT2f(1.0, 1.0, 1.0, 0.0, 0.0);
+    sgl.v3fT2f(1.0, -1.0, -1.0, 0.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(-1.0, -1.0, 1.0, 1.0, 0.0);
     sgl.v3fT2f(-1.0, -1.0, -1.0, 0.0, 0.0);
-    sgl.v3fT2f(-1.0,  1.0, -1.0, 0.0, 1.0);
-    sgl.v3fT2f(-1.0,  1.0,  1.0, 1.0, 1.0);
-    sgl.v3fT2f( 1.0,  1.0,  1.0, 1.0, 0.0);
-    sgl.v3fT2f( 1.0,  1.0, -1.0, 0.0, 0.0);
+    sgl.v3fT2f(-1.0, 1.0, -1.0, 0.0, 1.0);
+    sgl.v3fT2f(-1.0, 1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, 1.0, 1.0, 0.0);
+    sgl.v3fT2f(1.0, 1.0, -1.0, 0.0, 0.0);
     sgl.end();
 }

--- a/src/examples/sgl-context.zig
+++ b/src/examples/sgl-context.zig
@@ -49,7 +49,10 @@ export fn init() void {
     });
 
     // initialize a pass action struct for the default pass to clear to a light-blue color
-    state.display.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.5, .g = 0.7, .b = 1, .a = 1 } };
+    state.display.pass_action.colors[0] = .{
+        .action = .CLEAR,
+        .value = .{ .r = 0.5, .g = 0.7, .b = 1, .a = 1 },
+    };
 
     // create a sokol-gl pipeline object for 3D rendering into the default pass
     state.display.sgl_pip = sgl.contextMakePipeline(sgl.defaultContext(), .{
@@ -108,11 +111,7 @@ export fn frame() void {
     sgl.loadPipeline(state.display.sgl_pip);
     sgl.matrixModeProjection();
     sgl.perspective(sgl.asRadians(45.0), sapp.widthf() / sapp.heightf(), 0.1, 100.0);
-    const eye = .{
-        math.sin(a) * 6.0,
-        math.sin(a) * 3.0,
-        math.cos(a) * 6.0,
-    };
+    const eye = .{ math.sin(a) * 6.0, math.sin(a) * 3.0, math.cos(a) * 6.0 };
     sgl.matrixModeModelview();
     sgl.lookat(eye[0], eye[1], eye[2], 0, 0, 0, 0, 1, 0);
     draw_cube();

--- a/src/examples/sgl-context.zig
+++ b/src/examples/sgl-context.zig
@@ -93,7 +93,7 @@ export fn init() void {
 }
 
 export fn frame() void {
-    const a = sgl.asRadians(@intToFloat(f32, sapp.frameCount()));
+    const a = sgl.asRadians(@floatFromInt(f32, sapp.frameCount()));
 
     // draw a rotating quad into the offscreen render target texture
     sgl.setContext(state.offscreen.sgl_ctx);

--- a/src/examples/sgl-points.zig
+++ b/src/examples/sgl-points.zig
@@ -49,7 +49,7 @@ export fn init() void {
 }
 
 fn computeColor(t: f32) Rgb {
-    const idx0 = @floatToInt(usize, t * 16) % 16;
+    const idx0 = @intFromFloat(usize, t * 16) % 16;
     const idx1 = (idx0 + 1) % 16;
     const l = (t * 16) - @floor(t * 16);
     const c0 = palette[idx0];
@@ -62,15 +62,15 @@ fn computeColor(t: f32) Rgb {
 }
 
 export fn frame() void {
-    const angle = @intToFloat(f32, sapp.frameCount() % 360);
+    const angle = @floatFromInt(f32, sapp.frameCount() % 360);
 
     sgl.defaults();
     sgl.beginPoints();
     var psize: f32 = 5;
     var i: usize = 0;
     while (i < 300): (i += 1) {
-        const a = sgl.asRadians(angle + @intToFloat(f32,i));
-        const color = computeColor(@intToFloat(f32, (sapp.frameCount() + i) % 300) / 300);
+        const a = sgl.asRadians(angle + @floatFromInt(f32,i));
+        const color = computeColor(@floatFromInt(f32, (sapp.frameCount() + i) % 300) / 300);
         const r = math.sin(a * 4.0);
         const s = math.sin(a);
         const c = math.cos(a);

--- a/src/examples/sgl-points.zig
+++ b/src/examples/sgl-points.zig
@@ -54,7 +54,11 @@ fn computeColor(t: f32) Rgb {
     const l = (t * 16) - @floor(t * 16);
     const c0 = palette[idx0];
     const c1 = palette[idx1];
-    return .{ .r = (c0.r * (1 - l)) + (c1.r * l), .g = (c0.g * (1 - l)) + (c1.g * l), .b = (c0.b * (1 - l)) + (c1.b * l) };
+    return .{
+        .r = (c0.r * (1 - l)) + (c1.r * l),
+        .g = (c0.g * (1 - l)) + (c1.g * l),
+        .b = (c0.b * (1 - l)) + (c1.b * l),
+    };
 }
 
 export fn frame() void {

--- a/src/examples/sgl-points.zig
+++ b/src/examples/sgl-points.zig
@@ -6,10 +6,10 @@
 //  (port of this C sample: https://floooh.github.io/sokol-html5/sgl-points-sapp.html)
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
-const sgl   = sokol.gl;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
+const sgl = sokol.gl;
 const sgapp = sokol.app_gfx_glue;
 const math = @import("std").math;
 
@@ -18,23 +18,23 @@ const state = struct {
     var pass_action = sg.PassAction{};
 };
 
-const palette = [16]Rgb {
-    .{ .r=0.957, .g=0.263, .b=0.212 },
-    .{ .r=0.914, .g=0.118, .b=0.388 },
-    .{ .r=0.612, .g=0.153, .b=0.690 },
-    .{ .r=0.404, .g=0.227, .b=0.718 },
-    .{ .r=0.247, .g=0.318, .b=0.710 },
-    .{ .r=0.129, .g=0.588, .b=0.953 },
-    .{ .r=0.012, .g=0.663, .b=0.957 },
-    .{ .r=0.000, .g=0.737, .b=0.831 },
-    .{ .r=0.000, .g=0.588, .b=0.533 },
-    .{ .r=0.298, .g=0.686, .b=0.314 },
-    .{ .r=0.545, .g=0.765, .b=0.290 },
-    .{ .r=0.804, .g=0.863, .b=0.224 },
-    .{ .r=1.000, .g=0.922, .b=0.231 },
-    .{ .r=1.000, .g=0.757, .b=0.027 },
-    .{ .r=1.000, .g=0.596, .b=0.000 },
-    .{ .r=1.000, .g=0.341, .b=0.133 },
+const palette = [16]Rgb{
+    .{ .r = 0.957, .g = 0.263, .b = 0.212 },
+    .{ .r = 0.914, .g = 0.118, .b = 0.388 },
+    .{ .r = 0.612, .g = 0.153, .b = 0.690 },
+    .{ .r = 0.404, .g = 0.227, .b = 0.718 },
+    .{ .r = 0.247, .g = 0.318, .b = 0.710 },
+    .{ .r = 0.129, .g = 0.588, .b = 0.953 },
+    .{ .r = 0.012, .g = 0.663, .b = 0.957 },
+    .{ .r = 0.000, .g = 0.737, .b = 0.831 },
+    .{ .r = 0.000, .g = 0.588, .b = 0.533 },
+    .{ .r = 0.298, .g = 0.686, .b = 0.314 },
+    .{ .r = 0.545, .g = 0.765, .b = 0.290 },
+    .{ .r = 0.804, .g = 0.863, .b = 0.224 },
+    .{ .r = 1.000, .g = 0.922, .b = 0.231 },
+    .{ .r = 1.000, .g = 0.757, .b = 0.027 },
+    .{ .r = 1.000, .g = 0.596, .b = 0.000 },
+    .{ .r = 1.000, .g = 0.341, .b = 0.133 },
 };
 
 export fn init() void {
@@ -45,32 +45,28 @@ export fn init() void {
     sgl.setup(.{
         .logger = .{ .func = slog.func },
     });
-    state.pass_action.colors[0] = .{ .action=.CLEAR, .value=.{ .r=0, .g=0, .b=0 } };
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0 } };
 }
 
 fn computeColor(t: f32) Rgb {
-    const idx0 = @intFromFloat(usize, t * 16) % 16;
+    const idx0 = @as(usize, @intFromFloat(t * 16)) % 16;
     const idx1 = (idx0 + 1) % 16;
     const l = (t * 16) - @floor(t * 16);
     const c0 = palette[idx0];
     const c1 = palette[idx1];
-    return .{
-        .r = (c0.r * (1 - l)) + (c1.r * l),
-        .g = (c0.g * (1 - l)) + (c1.g * l),
-        .b = (c0.b * (1 - l)) + (c1.b * l)
-    };
+    return .{ .r = (c0.r * (1 - l)) + (c1.r * l), .g = (c0.g * (1 - l)) + (c1.g * l), .b = (c0.b * (1 - l)) + (c1.b * l) };
 }
 
 export fn frame() void {
-    const angle = @floatFromInt(f32, sapp.frameCount() % 360);
+    const angle = @as(f32, @floatFromInt(sapp.frameCount() % 360));
 
     sgl.defaults();
     sgl.beginPoints();
     var psize: f32 = 5;
     var i: usize = 0;
-    while (i < 300): (i += 1) {
-        const a = sgl.asRadians(angle + @floatFromInt(f32,i));
-        const color = computeColor(@floatFromInt(f32, (sapp.frameCount() + i) % 300) / 300);
+    while (i < 300) : (i += 1) {
+        const a = sgl.asRadians(angle + @as(f32, @floatFromInt(i)));
+        const color = computeColor(@as(f32, @floatFromInt((sapp.frameCount() + i) % 300)) / 300);
         const r = math.sin(a * 4.0);
         const s = math.sin(a);
         const c = math.cos(a);

--- a/src/examples/sgl.zig
+++ b/src/examples/sgl.zig
@@ -4,12 +4,12 @@
 //  sokol_gl.h / sokol.sgl sample program.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
-const sgl   = sokol.gl;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
+const sgl = sokol.gl;
 const sgapp = sokol.app_gfx_glue;
-const math  = @import("std").math;
+const math = @import("std").math;
 
 const state = struct {
     var pass_action: sg.PassAction = .{};
@@ -44,9 +44,9 @@ export fn init() void {
     const pixels = init: {
         var res: [img_width][img_height]u32 = undefined;
         var y: usize = 0;
-        while (y < img_height): (y += 1) {
+        while (y < img_height) : (y += 1) {
             var x: usize = 0;
-            while (x < img_width): (x += 1) {
+            while (x < img_width) : (x += 1) {
                 res[y][x] = if (0 == (y ^ x) & 1) 0xFF_00_00_00 else 0xFF_FF_FF_FF;
             }
         }
@@ -73,12 +73,12 @@ export fn init() void {
     });
 
     // pass-action to clear to black
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0, .b=0, .a=1 }};
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0, .a = 1 } };
 }
 
 export fn frame() void {
     // frame time 'normalized' to 60fps
-    const dt = @floatCast(f32, sapp.frameDuration()) * 60.0;
+    const dt = @as(f32, @floatCast(sapp.frameDuration())) * 60.0;
 
     // compute viewport rectangles so that the views are horizontally
     // centered and keep a 1:1 aspect ratio
@@ -115,9 +115,9 @@ export fn cleanup() void {
 fn drawTriangle() void {
     sgl.defaults();
     sgl.beginTriangles();
-    sgl.v2fC3b( 0.0,  0.5, 255, 0, 0);
+    sgl.v2fC3b(0.0, 0.5, 255, 0, 0);
     sgl.v2fC3b(-0.5, -0.5, 0, 0, 255);
-    sgl.v2fC3b( 0.5, -0.5, 0, 255, 0);
+    sgl.v2fC3b(0.5, -0.5, 0, 255, 0);
     sgl.end();
 }
 
@@ -128,10 +128,10 @@ fn drawQuad(dt: f32) void {
     sgl.rotate(sgl.asRadians(state.quad.rot), 0.0, 0.0, 1.0);
     sgl.scale(scale, scale, 1.0);
     sgl.beginQuads();
-    sgl.v2fC3b( -0.5, -0.5,  255, 255, 0);
-    sgl.v2fC3b(  0.5, -0.5,  0, 255, 0);
-    sgl.v2fC3b(  0.5,  0.5,  0, 0, 255);
-    sgl.v2fC3b( -0.5,  0.5,  255, 0, 0);
+    sgl.v2fC3b(-0.5, -0.5, 255, 255, 0);
+    sgl.v2fC3b(0.5, -0.5, 0, 255, 0);
+    sgl.v2fC3b(0.5, 0.5, 0, 0, 255);
+    sgl.v2fC3b(-0.5, 0.5, 255, 0, 0);
     sgl.end();
 }
 
@@ -139,35 +139,35 @@ fn drawQuad(dt: f32) void {
 fn drawCube() void {
     sgl.beginQuads();
     sgl.c3f(1.0, 0.0, 0.0);
-        sgl.v3fT2f(-1.0,  1.0, -1.0, -1.0,  1.0);
-        sgl.v3fT2f( 1.0,  1.0, -1.0,  1.0,  1.0);
-        sgl.v3fT2f( 1.0, -1.0, -1.0,  1.0, -1.0);
-        sgl.v3fT2f(-1.0, -1.0, -1.0, -1.0, -1.0);
+    sgl.v3fT2f(-1.0, 1.0, -1.0, -1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, -1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, -1.0, 1.0, -1.0);
+    sgl.v3fT2f(-1.0, -1.0, -1.0, -1.0, -1.0);
     sgl.c3f(0.0, 1.0, 0.0);
-        sgl.v3fT2f(-1.0, -1.0,  1.0, -1.0,  1.0);
-        sgl.v3fT2f( 1.0, -1.0,  1.0,  1.0,  1.0);
-        sgl.v3fT2f( 1.0,  1.0,  1.0,  1.0, -1.0);
-        sgl.v3fT2f(-1.0,  1.0,  1.0, -1.0, -1.0);
+    sgl.v3fT2f(-1.0, -1.0, 1.0, -1.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, 1.0, 1.0, -1.0);
+    sgl.v3fT2f(-1.0, 1.0, 1.0, -1.0, -1.0);
     sgl.c3f(0.0, 0.0, 1.0);
-        sgl.v3fT2f(-1.0, -1.0,  1.0, -1.0,  1.0);
-        sgl.v3fT2f(-1.0,  1.0,  1.0,  1.0,  1.0);
-        sgl.v3fT2f(-1.0,  1.0, -1.0,  1.0, -1.0);
-        sgl.v3fT2f(-1.0, -1.0, -1.0, -1.0, -1.0);
+    sgl.v3fT2f(-1.0, -1.0, 1.0, -1.0, 1.0);
+    sgl.v3fT2f(-1.0, 1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(-1.0, 1.0, -1.0, 1.0, -1.0);
+    sgl.v3fT2f(-1.0, -1.0, -1.0, -1.0, -1.0);
     sgl.c3f(1.0, 0.5, 0.0);
-        sgl.v3fT2f(1.0, -1.0,  1.0, -1.0,   1.0);
-        sgl.v3fT2f(1.0, -1.0, -1.0,  1.0,   1.0);
-        sgl.v3fT2f(1.0,  1.0, -1.0,  1.0,  -1.0);
-        sgl.v3fT2f(1.0,  1.0,  1.0, -1.0,  -1.0);
+    sgl.v3fT2f(1.0, -1.0, 1.0, -1.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, -1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, -1.0, 1.0, -1.0);
+    sgl.v3fT2f(1.0, 1.0, 1.0, -1.0, -1.0);
     sgl.c3f(0.0, 0.5, 1.0);
-        sgl.v3fT2f( 1.0, -1.0, -1.0, -1.0,  1.0);
-        sgl.v3fT2f( 1.0, -1.0,  1.0,  1.0,  1.0);
-        sgl.v3fT2f(-1.0, -1.0,  1.0,  1.0, -1.0);
-        sgl.v3fT2f(-1.0, -1.0, -1.0, -1.0, -1.0);
+    sgl.v3fT2f(1.0, -1.0, -1.0, -1.0, 1.0);
+    sgl.v3fT2f(1.0, -1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(-1.0, -1.0, 1.0, 1.0, -1.0);
+    sgl.v3fT2f(-1.0, -1.0, -1.0, -1.0, -1.0);
     sgl.c3f(1.0, 0.0, 0.5);
-        sgl.v3fT2f(-1.0,  1.0, -1.0, -1.0,  1.0);
-        sgl.v3fT2f(-1.0,  1.0,  1.0,  1.0,  1.0);
-        sgl.v3fT2f( 1.0,  1.0,  1.0,  1.0, -1.0);
-        sgl.v3fT2f( 1.0,  1.0, -1.0, -1.0, -1.0);
+    sgl.v3fT2f(-1.0, 1.0, -1.0, -1.0, 1.0);
+    sgl.v3fT2f(-1.0, 1.0, 1.0, 1.0, 1.0);
+    sgl.v3fT2f(1.0, 1.0, 1.0, 1.0, -1.0);
+    sgl.v3fT2f(1.0, 1.0, -1.0, -1.0, -1.0);
     sgl.end();
 }
 
@@ -187,18 +187,18 @@ fn drawCubes(dt: f32) void {
     sgl.rotate(sgl.asRadians(state.cube.rot_y), 0.0, 1.0, 0.0);
     drawCube();
     sgl.pushMatrix();
-        sgl.translate(0.0, 0.0, 3.0);
-        sgl.scale(0.5, 0.5, 0.5);
-        sgl.rotate(-2.0 * sgl.asRadians(state.cube.rot_x), 1.0, 0.0, 0.0);
-        sgl.rotate(-2.0 * sgl.asRadians(state.cube.rot_y), 0.0, 1.0, 0.0);
-        drawCube();
-        sgl.pushMatrix();
-            sgl.translate(0.0, 0.0, 3.0);
-            sgl.scale(0.5, 0.5, 0.5);
-            sgl.rotate(-3.0 * sgl.asRadians(state.cube.rot_x), 1.0, 0.0, 0.0);
-            sgl.rotate(3.0 * sgl.asRadians(state.cube.rot_y), 0.0, 0.0, 1.0);
-            drawCube();
-        sgl.popMatrix();
+    sgl.translate(0.0, 0.0, 3.0);
+    sgl.scale(0.5, 0.5, 0.5);
+    sgl.rotate(-2.0 * sgl.asRadians(state.cube.rot_x), 1.0, 0.0, 0.0);
+    sgl.rotate(-2.0 * sgl.asRadians(state.cube.rot_y), 0.0, 1.0, 0.0);
+    drawCube();
+    sgl.pushMatrix();
+    sgl.translate(0.0, 0.0, 3.0);
+    sgl.scale(0.5, 0.5, 0.5);
+    sgl.rotate(-3.0 * sgl.asRadians(state.cube.rot_x), 1.0, 0.0, 0.0);
+    sgl.rotate(3.0 * sgl.asRadians(state.cube.rot_y), 0.0, 0.0, 1.0);
+    drawCube();
+    sgl.popMatrix();
     sgl.popMatrix();
 }
 

--- a/src/examples/shapes.zig
+++ b/src/examples/shapes.zig
@@ -3,17 +3,17 @@
 //
 //  Simple sokol.shape demo.
 //------------------------------------------------------------------------------
-const sokol  = @import("sokol");
-const slog   = sokol.log;
-const sg     = sokol.gfx;
-const sapp   = sokol.app;
-const sgapp  = sokol.app_gfx_glue;
-const sdtx   = sokol.debugtext;
+const sokol = @import("sokol");
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
+const sgapp = sokol.app_gfx_glue;
+const sdtx = sokol.debugtext;
 const sshape = sokol.shape;
-const vec3   = @import("math.zig").Vec3;
-const mat4   = @import("math.zig").Mat4;
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
 const assert = @import("std").debug.assert;
-const shd    = @import("shaders/shapes.glsl.zig");
+const shd = @import("shaders/shapes.glsl.zig");
 
 const Shape = struct {
     pos: vec3 = vec3.zero(),
@@ -24,19 +24,19 @@ const NUM_SHAPES = 5;
 
 const state = struct {
     var pass_action: sg.PassAction = .{};
-    var pip:         sg.Pipeline = .{};
-    var bind:        sg.Bindings = .{};
-    var vs_params:   shd.VsParams = undefined;
-    var shapes:      [NUM_SHAPES]Shape = .{
-        .{ .pos = .{ .x=-1, .y=1,  .z=0 } },
-        .{ .pos = .{ .x=1,  .y=1,  .z=0 } },
-        .{ .pos = .{ .x=-2, .y=-1, .z=0 } },
-        .{ .pos = .{ .x=2,  .y=-1, .z=0 } },
-        .{ .pos = .{ .x=0,  .y=-1, .z=0 } },
+    var pip: sg.Pipeline = .{};
+    var bind: sg.Bindings = .{};
+    var vs_params: shd.VsParams = undefined;
+    var shapes: [NUM_SHAPES]Shape = .{
+        .{ .pos = .{ .x = -1, .y = 1, .z = 0 } },
+        .{ .pos = .{ .x = 1, .y = 1, .z = 0 } },
+        .{ .pos = .{ .x = -2, .y = -1, .z = 0 } },
+        .{ .pos = .{ .x = 2, .y = -1, .z = 0 } },
+        .{ .pos = .{ .x = 0, .y = -1, .z = 0 } },
     };
     var rx: f32 = 0.0;
     var ry: f32 = 0.0;
-    const view = mat4.lookat(.{.x=0.0, .y=1.5, .z=6.0}, vec3.zero(), vec3.up());
+    const view = mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 6.0 }, vec3.zero(), vec3.up());
 };
 
 export fn init() void {
@@ -52,7 +52,7 @@ export fn init() void {
     sdtx.setup(sdtx_desc);
 
     // pass-action for clearing to black
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0, .g=0, .b=0, .a=1 }};
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0, .g = 0, .b = 0, .a = 1 } };
 
     // shader- and pipeline-object
     var pip_desc: sg.PipelineDesc = .{
@@ -66,27 +66,27 @@ export fn init() void {
     };
     pip_desc.layout.buffers[0] = sshape.bufferLayoutDesc();
     pip_desc.layout.attrs[shd.ATTR_vs_position] = sshape.positionAttrDesc();
-    pip_desc.layout.attrs[shd.ATTR_vs_normal]   = sshape.normalAttrDesc();
+    pip_desc.layout.attrs[shd.ATTR_vs_normal] = sshape.normalAttrDesc();
     pip_desc.layout.attrs[shd.ATTR_vs_texcoord] = sshape.texcoordAttrDesc();
-    pip_desc.layout.attrs[shd.ATTR_vs_color0]   = sshape.colorAttrDesc();
+    pip_desc.layout.attrs[shd.ATTR_vs_color0] = sshape.colorAttrDesc();
     state.pip = sg.makePipeline(pip_desc);
 
     // generate shape geometries
-    var vertices: [6*1024]sshape.Vertex = undefined;
-    var indices:  [16*1024]u16 = undefined;
+    var vertices: [6 * 1024]sshape.Vertex = undefined;
+    var indices: [16 * 1024]u16 = undefined;
     var buf: sshape.Buffer = .{
         .vertices = .{ .buffer = sshape.asRange(&vertices) },
-        .indices  = .{ .buffer = sshape.asRange(&indices) },
+        .indices = .{ .buffer = sshape.asRange(&indices) },
     };
-    buf = sshape.buildBox(buf, .{ .width=1.0, .height=1.0, .depth=1.0, .tiles=10, .random_colors=true });
+    buf = sshape.buildBox(buf, .{ .width = 1.0, .height = 1.0, .depth = 1.0, .tiles = 10, .random_colors = true });
     state.shapes[0].draw = sshape.elementRange(buf);
-    buf = sshape.buildPlane(buf, .{ .width=1.0, .depth=1.0, .tiles=10, .random_colors=true });
+    buf = sshape.buildPlane(buf, .{ .width = 1.0, .depth = 1.0, .tiles = 10, .random_colors = true });
     state.shapes[1].draw = sshape.elementRange(buf);
-    buf = sshape.buildSphere(buf, .{ .radius=0.75, .slices=36, .stacks=20, .random_colors=true });
+    buf = sshape.buildSphere(buf, .{ .radius = 0.75, .slices = 36, .stacks = 20, .random_colors = true });
     state.shapes[2].draw = sshape.elementRange(buf);
-    buf = sshape.buildCylinder(buf, .{ .radius=0.5, .height=1.5, .slices=36, .stacks=10, .random_colors=true });
+    buf = sshape.buildCylinder(buf, .{ .radius = 0.5, .height = 1.5, .slices = 36, .stacks = 10, .random_colors = true });
     state.shapes[3].draw = sshape.elementRange(buf);
-    buf = sshape.buildTorus(buf, .{ .radius=0.5, .ring_radius=0.3, .rings=36, .sides=18, .random_colors=true });
+    buf = sshape.buildTorus(buf, .{ .radius = 0.5, .ring_radius = 0.3, .rings = 36, .sides = 18, .random_colors = true });
     state.shapes[4].draw = sshape.elementRange(buf);
     assert(buf.valid);
 
@@ -105,16 +105,16 @@ export fn frame() void {
     sdtx.puts("  3: vertex colors\n");
 
     // view-project matrix
-    const proj = mat4.persp(60.0, sapp.widthf()/sapp.heightf(), 0.01, 10.0);
+    const proj = mat4.persp(60.0, sapp.widthf() / sapp.heightf(), 0.01, 10.0);
     const view_proj = mat4.mul(proj, state.view);
 
     // model-rotation matrix
-    const dt = @floatCast(f32, sapp.frameDuration()) * 60.0;
+    const dt = @as(f32, @floatCast(sapp.frameDuration())) * 60.0;
     state.rx += 1.0 * dt;
     state.ry += 1.0 * dt;
-    const rxm = mat4.rotate(state.rx, .{ .x=1, .y=0, .z=0 });
-    const rym = mat4.rotate(state.ry, .{ .x=0, .y=1, .z=0 });
-    const rm  = mat4.mul(rxm, rym);
+    const rxm = mat4.rotate(state.rx, .{ .x = 1, .y = 0, .z = 0 });
+    const rym = mat4.rotate(state.ry, .{ .x = 0, .y = 1, .z = 0 });
+    const rm = mat4.mul(rxm, rym);
 
     // render shapes...
     sg.beginDefaultPass(state.pass_action, sapp.width(), sapp.height());
@@ -139,7 +139,7 @@ export fn input(event: ?*const sapp.Event) void {
             ._1 => 0.0,
             ._2 => 1.0,
             ._3 => 2.0,
-            else => state.vs_params.draw_mode
+            else => state.vs_params.draw_mode,
         };
     }
 }

--- a/src/examples/texcube.zig
+++ b/src/examples/texcube.zig
@@ -74,7 +74,17 @@ export fn init() void {
     });
 
     // cube index buffer
-    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
+    state.bind.index_buffer = sg.makeBuffer(.{
+        .type = .INDEXBUFFER,
+        .data = sg.asRange(&[_]u16{
+            0,  1,  2,  0,  2,  3,
+            6,  5,  4,  7,  6,  4,
+            8,  9,  10, 8,  10, 11,
+            14, 13, 12, 15, 14, 12,
+            16, 17, 18, 16, 18, 19,
+            22, 21, 20, 23, 22, 20,
+        }),
+    });
 
     // create a small checker-board texture
     var img_desc: sg.ImageDesc = .{
@@ -90,10 +100,15 @@ export fn init() void {
     state.bind.fs_images[shd.SLOT_tex] = sg.makeImage(img_desc);
 
     // shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.texcubeShaderDesc(sg.queryBackend())), .index_type = .UINT16, .depth = .{
-        .compare = .LESS_EQUAL,
-        .write_enabled = true,
-    }, .cull_mode = .BACK };
+    var pip_desc: sg.PipelineDesc = .{
+        .shader = sg.makeShader(shd.texcubeShaderDesc(sg.queryBackend())),
+        .index_type = .UINT16,
+        .depth = .{
+            .compare = .LESS_EQUAL,
+            .write_enabled = true,
+        },
+        .cull_mode = .BACK,
+    };
     pip_desc.layout.attrs[shd.ATTR_vs_pos].format = .FLOAT3;
     pip_desc.layout.attrs[shd.ATTR_vs_color0].format = .UBYTE4N;
     pip_desc.layout.attrs[shd.ATTR_vs_texcoord0].format = .SHORT2N;

--- a/src/examples/texcube.zig
+++ b/src/examples/texcube.zig
@@ -4,13 +4,13 @@
 //  Texture creation, rendering with texture, packed vertex components.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
-const vec3  = @import("math.zig").Vec3;
-const mat4  = @import("math.zig").Mat4;
-const shd   = @import("shaders/texcube.glsl.zig");
+const vec3 = @import("math.zig").Vec3;
+const mat4 = @import("math.zig").Mat4;
+const shd = @import("shaders/texcube.glsl.zig");
 
 const state = struct {
     var rx: f32 = 0.0;
@@ -18,15 +18,11 @@ const state = struct {
     var pass_action: sg.PassAction = .{};
     var pip: sg.Pipeline = .{};
     var bind: sg.Bindings = .{};
-    const view: mat4 = mat4.lookat(.{ .x=0.0, .y=1.5, .z=6.0 }, vec3.zero(), vec3.up());
+    const view: mat4 = mat4.lookat(.{ .x = 0.0, .y = 1.5, .z = 6.0 }, vec3.zero(), vec3.up());
 };
 
 // a vertex struct with position, color and uv-coords
-const Vertex = extern struct {
-    x: f32, y: f32, z: f32,
-    color: u32,
-    u: i16, v: i16
-};
+const Vertex = extern struct { x: f32, y: f32, z: f32, color: u32, u: i16, v: i16 };
 
 export fn init() void {
     sg.setup(.{
@@ -45,57 +41,47 @@ export fn init() void {
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
         .data = sg.asRange(&[_]Vertex{
             // pos                         color              texcoords
-            .{ .x=-1.0, .y=-1.0, .z=-1.0,  .color=0xFF0000FF, .u=    0, .v=    0 },
-            .{ .x= 1.0, .y=-1.0, .z=-1.0,  .color=0xFF0000FF, .u=32767, .v=    0 },
-            .{ .x= 1.0, .y= 1.0, .z=-1.0,  .color=0xFF0000FF, .u=32767, .v=32767 },
-            .{ .x=-1.0, .y= 1.0, .z=-1.0,  .color=0xFF0000FF, .u=    0, .v=32767 },
+            .{ .x = -1.0, .y = -1.0, .z = -1.0, .color = 0xFF0000FF, .u = 0, .v = 0 },
+            .{ .x = 1.0, .y = -1.0, .z = -1.0, .color = 0xFF0000FF, .u = 32767, .v = 0 },
+            .{ .x = 1.0, .y = 1.0, .z = -1.0, .color = 0xFF0000FF, .u = 32767, .v = 32767 },
+            .{ .x = -1.0, .y = 1.0, .z = -1.0, .color = 0xFF0000FF, .u = 0, .v = 32767 },
 
-            .{ .x=-1.0, .y=-1.0, .z= 1.0,  .color=0xFF00FF00, .u=    0, .v=    0 },
-            .{ .x= 1.0, .y=-1.0, .z= 1.0,  .color=0xFF00FF00, .u=32767, .v=    0 },
-            .{ .x= 1.0, .y= 1.0, .z= 1.0,  .color=0xFF00FF00, .u=32767, .v=32767 },
-            .{ .x=-1.0, .y= 1.0, .z= 1.0,  .color=0xFF00FF00, .u=    0, .v=32767 },
+            .{ .x = -1.0, .y = -1.0, .z = 1.0, .color = 0xFF00FF00, .u = 0, .v = 0 },
+            .{ .x = 1.0, .y = -1.0, .z = 1.0, .color = 0xFF00FF00, .u = 32767, .v = 0 },
+            .{ .x = 1.0, .y = 1.0, .z = 1.0, .color = 0xFF00FF00, .u = 32767, .v = 32767 },
+            .{ .x = -1.0, .y = 1.0, .z = 1.0, .color = 0xFF00FF00, .u = 0, .v = 32767 },
 
-            .{ .x=-1.0, .y=-1.0, .z=-1.0,  .color=0xFFFF0000, .u=    0, .v=    0 },
-            .{ .x=-1.0, .y= 1.0, .z=-1.0,  .color=0xFFFF0000, .u=32767, .v=    0 },
-            .{ .x=-1.0, .y= 1.0, .z= 1.0,  .color=0xFFFF0000, .u=32767, .v=32767 },
-            .{ .x=-1.0, .y=-1.0, .z= 1.0,  .color=0xFFFF0000, .u=    0, .v=32767 },
+            .{ .x = -1.0, .y = -1.0, .z = -1.0, .color = 0xFFFF0000, .u = 0, .v = 0 },
+            .{ .x = -1.0, .y = 1.0, .z = -1.0, .color = 0xFFFF0000, .u = 32767, .v = 0 },
+            .{ .x = -1.0, .y = 1.0, .z = 1.0, .color = 0xFFFF0000, .u = 32767, .v = 32767 },
+            .{ .x = -1.0, .y = -1.0, .z = 1.0, .color = 0xFFFF0000, .u = 0, .v = 32767 },
 
-            .{ .x= 1.0, .y=-1.0, .z=-1.0,  .color=0xFFFF007F, .u=    0, .v=    0 },
-            .{ .x= 1.0, .y= 1.0, .z=-1.0,  .color=0xFFFF007F, .u=32767, .v=    0 },
-            .{ .x= 1.0, .y= 1.0, .z= 1.0,  .color=0xFFFF007F, .u=32767, .v=32767 },
-            .{ .x= 1.0, .y=-1.0, .z= 1.0,  .color=0xFFFF007F, .u=    0, .v=32767 },
+            .{ .x = 1.0, .y = -1.0, .z = -1.0, .color = 0xFFFF007F, .u = 0, .v = 0 },
+            .{ .x = 1.0, .y = 1.0, .z = -1.0, .color = 0xFFFF007F, .u = 32767, .v = 0 },
+            .{ .x = 1.0, .y = 1.0, .z = 1.0, .color = 0xFFFF007F, .u = 32767, .v = 32767 },
+            .{ .x = 1.0, .y = -1.0, .z = 1.0, .color = 0xFFFF007F, .u = 0, .v = 32767 },
 
-            .{ .x=-1.0, .y=-1.0, .z=-1.0,  .color=0xFFFF7F00, .u=    0, .v=    0 },
-            .{ .x=-1.0, .y=-1.0, .z= 1.0,  .color=0xFFFF7F00, .u=32767, .v=    0 },
-            .{ .x= 1.0, .y=-1.0, .z= 1.0,  .color=0xFFFF7F00, .u=32767, .v=32767 },
-            .{ .x= 1.0, .y=-1.0, .z=-1.0,  .color=0xFFFF7F00, .u=    0, .v=32767 },
+            .{ .x = -1.0, .y = -1.0, .z = -1.0, .color = 0xFFFF7F00, .u = 0, .v = 0 },
+            .{ .x = -1.0, .y = -1.0, .z = 1.0, .color = 0xFFFF7F00, .u = 32767, .v = 0 },
+            .{ .x = 1.0, .y = -1.0, .z = 1.0, .color = 0xFFFF7F00, .u = 32767, .v = 32767 },
+            .{ .x = 1.0, .y = -1.0, .z = -1.0, .color = 0xFFFF7F00, .u = 0, .v = 32767 },
 
-            .{ .x=-1.0, .y= 1.0, .z=-1.0,  .color=0xFF007FFF, .u=    0, .v=    0 },
-            .{ .x=-1.0, .y= 1.0, .z= 1.0,  .color=0xFF007FFF, .u=32767, .v=    0 },
-            .{ .x= 1.0, .y= 1.0, .z= 1.0,  .color=0xFF007FFF, .u=32767, .v=32767 },
-            .{ .x= 1.0, .y= 1.0, .z=-1.0,  .color=0xFF007FFF, .u=    0, .v=32767 },
-        })
+            .{ .x = -1.0, .y = 1.0, .z = -1.0, .color = 0xFF007FFF, .u = 0, .v = 0 },
+            .{ .x = -1.0, .y = 1.0, .z = 1.0, .color = 0xFF007FFF, .u = 32767, .v = 0 },
+            .{ .x = 1.0, .y = 1.0, .z = 1.0, .color = 0xFF007FFF, .u = 32767, .v = 32767 },
+            .{ .x = 1.0, .y = 1.0, .z = -1.0, .color = 0xFF007FFF, .u = 0, .v = 32767 },
+        }),
     });
 
     // cube index buffer
-    state.bind.index_buffer = sg.makeBuffer(.{
-        .type = .INDEXBUFFER,
-        .data = sg.asRange(&[_]u16{
-            0, 1, 2,  0, 2, 3,
-            6, 5, 4,  7, 6, 4,
-            8, 9, 10,  8, 10, 11,
-            14, 13, 12,  15, 14, 12,
-            16, 17, 18,  16, 18, 19,
-            22, 21, 20,  23, 22, 20
-        })
-    });
+    state.bind.index_buffer = sg.makeBuffer(.{ .type = .INDEXBUFFER, .data = sg.asRange(&[_]u16{ 0, 1, 2, 0, 2, 3, 6, 5, 4, 7, 6, 4, 8, 9, 10, 8, 10, 11, 14, 13, 12, 15, 14, 12, 16, 17, 18, 16, 18, 19, 22, 21, 20, 23, 22, 20 }) });
 
     // create a small checker-board texture
     var img_desc: sg.ImageDesc = .{
         .width = 4,
         .height = 4,
     };
-    img_desc.data.subimage[0][0] = sg.asRange(&[4*4]u32{
+    img_desc.data.subimage[0][0] = sg.asRange(&[4 * 4]u32{
         0xFFFFFFFF, 0xFF000000, 0xFFFFFFFF, 0xFF000000,
         0xFF000000, 0xFFFFFFFF, 0xFF000000, 0xFFFFFFFF,
         0xFFFFFFFF, 0xFF000000, 0xFFFFFFFF, 0xFF000000,
@@ -104,26 +90,21 @@ export fn init() void {
     state.bind.fs_images[shd.SLOT_tex] = sg.makeImage(img_desc);
 
     // shader and pipeline object
-    var pip_desc: sg.PipelineDesc = .{
-        .shader = sg.makeShader(shd.texcubeShaderDesc(sg.queryBackend())),
-        .index_type = .UINT16,
-        .depth = .{
-            .compare = .LESS_EQUAL,
-            .write_enabled = true,
-        },
-        .cull_mode = .BACK
-    };
+    var pip_desc: sg.PipelineDesc = .{ .shader = sg.makeShader(shd.texcubeShaderDesc(sg.queryBackend())), .index_type = .UINT16, .depth = .{
+        .compare = .LESS_EQUAL,
+        .write_enabled = true,
+    }, .cull_mode = .BACK };
     pip_desc.layout.attrs[shd.ATTR_vs_pos].format = .FLOAT3;
     pip_desc.layout.attrs[shd.ATTR_vs_color0].format = .UBYTE4N;
     pip_desc.layout.attrs[shd.ATTR_vs_texcoord0].format = .SHORT2N;
     state.pip = sg.makePipeline(pip_desc);
 
     // pass action for clearing the frame buffer
-    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r=0.25, .g=0.5, .b=0.75, .a=1 } };
+    state.pass_action.colors[0] = .{ .action = .CLEAR, .value = .{ .r = 0.25, .g = 0.5, .b = 0.75, .a = 1 } };
 }
 
 export fn frame() void {
-    const dt = @floatCast(f32, sapp.frameDuration()) * 60.0;
+    const dt = @as(f32, @floatCast(sapp.frameDuration())) * 60.0;
 
     state.rx += 1.0 * dt;
     state.ry += 2.0 * dt;
@@ -157,12 +138,10 @@ pub fn main() void {
 }
 
 fn computeVsParams(rx: f32, ry: f32) shd.VsParams {
-    const rxm = mat4.rotate(rx, .{ .x=1.0, .y=0.0, .z=0.0 });
-    const rym = mat4.rotate(ry, .{ .x=0.0, .y=1.0, .z=0.0 });
+    const rxm = mat4.rotate(rx, .{ .x = 1.0, .y = 0.0, .z = 0.0 });
+    const rym = mat4.rotate(ry, .{ .x = 0.0, .y = 1.0, .z = 0.0 });
     const model = mat4.mul(rxm, rym);
     const aspect = sapp.widthf() / sapp.heightf();
     const proj = mat4.persp(60.0, aspect, 0.01, 10.0);
-    return shd.VsParams {
-        .mvp = mat4.mul(mat4.mul(proj, state.view), model)
-    };
+    return shd.VsParams{ .mvp = mat4.mul(mat4.mul(proj, state.view), model) };
 }

--- a/src/examples/triangle.zig
+++ b/src/examples/triangle.zig
@@ -4,9 +4,9 @@
 //  Vertex buffer, shader, pipeline state object.
 //------------------------------------------------------------------------------
 const sokol = @import("sokol");
-const slog  = sokol.log;
-const sg    = sokol.gfx;
-const sapp  = sokol.app;
+const slog = sokol.log;
+const sg = sokol.gfx;
+const sapp = sokol.app;
 const sgapp = sokol.app_gfx_glue;
 
 const state = struct {
@@ -24,17 +24,15 @@ export fn init() void {
     state.bind.vertex_buffers[0] = sg.makeBuffer(.{
         .data = sg.asRange(&[_]f32{
             // positions         colors
-             0.0,  0.5, 0.5,     1.0, 0.0, 0.0, 1.0,
-             0.5, -0.5, 0.5,     0.0, 1.0, 0.0, 1.0,
-            -0.5, -0.5, 0.5,     0.0, 0.0, 1.0, 1.0
-        })
+            0.0,  0.5,  0.5, 1.0, 0.0, 0.0, 1.0,
+            0.5,  -0.5, 0.5, 0.0, 1.0, 0.0, 1.0,
+            -0.5, -0.5, 0.5, 0.0, 0.0, 1.0, 1.0,
+        }),
     });
 
     // create a shader and pipeline object
     const shd = sg.makeShader(shaderDesc());
-    var pip_desc: sg.PipelineDesc = .{
-        .shader = shd
-    };
+    var pip_desc: sg.PipelineDesc = .{ .shader = shd };
     pip_desc.layout.attrs[0].format = .FLOAT3;
     pip_desc.layout.attrs[1].format = .FLOAT4;
     state.pip = sg.makePipeline(pip_desc);
@@ -93,12 +91,12 @@ fn shaderDesc() sg.ShaderDesc {
                 \\  outp.color = inp.color;
                 \\  return outp;
                 \\}
-                ;
+            ;
             desc.fs.source =
                 \\float4 main(float4 color: COLOR0): SV_Target0 {
                 \\  return color;
                 \\}
-                ;
+            ;
         },
         .GLCORE33 => {
             desc.attrs[0].name = "position";
@@ -112,7 +110,7 @@ fn shaderDesc() sg.ShaderDesc {
                 \\   gl_Position = position;
                 \\   color = color0;
                 \\ }
-                ;
+            ;
             desc.fs.source =
                 \\ #version 330
                 \\ in vec4 color;
@@ -120,7 +118,7 @@ fn shaderDesc() sg.ShaderDesc {
                 \\ void main() {
                 \\   frag_color = color;
                 \\ }
-                ;
+            ;
         },
         .METAL_MACOS => {
             desc.vs.source =
@@ -140,16 +138,16 @@ fn shaderDesc() sg.ShaderDesc {
                 \\   outp.color = inp.color;
                 \\   return outp;
                 \\ }
-                ;
+            ;
             desc.fs.source =
                 \\ #include <metal_stdlib>
                 \\ using namespace metal;
                 \\ fragment float4 _main(float4 color [[stage_in]]) {
                 \\   return color;
                 \\ };
-                ;
+            ;
         },
-        else => {}
+        else => {},
     }
     return desc;
 }

--- a/src/sokol/app.zig
+++ b/src/sokol/app.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 pub const max_touchpoints = 8;
 pub const max_mousebuttons = 3;
@@ -214,15 +214,15 @@ pub const Range = extern struct {
 pub const ImageDesc = extern struct {
     width: i32 = 0,
     height: i32 = 0,
-    pixels: Range = .{ },
+    pixels: Range = .{},
 };
 pub const IconDesc = extern struct {
     sokol_default: bool = false,
     images: [8]ImageDesc = [_]ImageDesc{.{}} ** 8,
 };
 pub const Allocator = extern struct {
-    alloc: ?*const fn(usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
-    free: ?*const fn(?*anyopaque, ?*anyopaque) callconv(.C) void = null,
+    alloc: ?*const fn (usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
+    free: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const LogItem = enum(i32) {
@@ -314,19 +314,19 @@ pub const LogItem = enum(i32) {
     CLIPBOARD_STRING_TOO_BIG,
 };
 pub const Logger = extern struct {
-    func: ?*const fn([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
+    func: ?*const fn ([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Desc = extern struct {
-    init_cb: ?*const fn() callconv(.C) void = null,
-    frame_cb: ?*const fn() callconv(.C) void = null,
-    cleanup_cb: ?*const fn() callconv(.C) void = null,
-    event_cb: ?*const fn([*c]const Event) callconv(.C) void = null,
+    init_cb: ?*const fn () callconv(.C) void = null,
+    frame_cb: ?*const fn () callconv(.C) void = null,
+    cleanup_cb: ?*const fn () callconv(.C) void = null,
+    event_cb: ?*const fn ([*c]const Event) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
-    init_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) void = null,
-    frame_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) void = null,
-    cleanup_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) void = null,
-    event_userdata_cb: ?*const fn([*c]const Event, ?*anyopaque) callconv(.C) void = null,
+    init_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) void = null,
+    frame_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) void = null,
+    cleanup_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) void = null,
+    event_userdata_cb: ?*const fn ([*c]const Event, ?*anyopaque) callconv(.C) void = null,
     width: i32 = 0,
     height: i32 = 0,
     sample_count: i32 = 0,
@@ -340,9 +340,9 @@ pub const Desc = extern struct {
     enable_dragndrop: bool = false,
     max_dropped_files: i32 = 0,
     max_dropped_file_path_length: i32 = 0,
-    icon: IconDesc = .{ },
-    allocator: Allocator = .{ },
-    logger: Logger = .{ },
+    icon: IconDesc = .{},
+    allocator: Allocator = .{},
+    logger: Logger = .{},
     gl_force_gles2: bool = false,
     gl_major_version: i32 = 0,
     gl_minor_version: i32 = 0,
@@ -365,14 +365,14 @@ pub const Html5FetchResponse = extern struct {
     succeeded: bool = false,
     error_code: Html5FetchError = .FETCH_ERROR_NO_ERROR,
     file_index: i32 = 0,
-    data: Range = .{ },
-    buffer: Range = .{ },
+    data: Range = .{},
+    buffer: Range = .{},
     user_data: ?*anyopaque = null,
 };
 pub const Html5FetchRequest = extern struct {
     dropped_file_index: i32 = 0,
-    callback: ?*const fn([*c]const Html5FetchResponse) callconv(.C) void = null,
-    buffer: Range = .{ },
+    callback: ?*const fn ([*c]const Html5FetchResponse) callconv(.C) void = null,
+    buffer: Range = .{},
     user_data: ?*anyopaque = null,
 };
 pub const MouseCursor = enum(i32) {
@@ -503,7 +503,7 @@ pub fn frameDuration() f64 {
 }
 pub extern fn sapp_set_clipboard_string([*c]const u8) void;
 pub fn setClipboardString(str: [:0]const u8) void {
-    sapp_set_clipboard_string(@ptrCast([*c]const u8,str));
+    sapp_set_clipboard_string(@as([*c]const u8, @ptrCast(str)));
 }
 pub extern fn sapp_get_clipboard_string() [*c]const u8;
 pub fn getClipboardString() [:0]const u8 {
@@ -511,7 +511,7 @@ pub fn getClipboardString() [:0]const u8 {
 }
 pub extern fn sapp_set_window_title([*c]const u8) void;
 pub fn setWindowTitle(str: [:0]const u8) void {
-    sapp_set_window_title(@ptrCast([*c]const u8,str));
+    sapp_set_window_title(@as([*c]const u8, @ptrCast(str)));
 }
 pub extern fn sapp_set_icon([*c]const IconDesc) void;
 pub fn setIcon(icon_desc: IconDesc) void {

--- a/src/sokol/app_gfx_glue.zig
+++ b/src/sokol/app_gfx_glue.zig
@@ -2,11 +2,29 @@ const sg = @import("gfx.zig");
 const sapp = @import("app.zig");
 
 pub fn context() sg.ContextDesc {
-    return sg.ContextDesc{ .color_format = sapp.colorFormat(), .depth_format = sapp.depthFormat(), .sample_count = sapp.sampleCount(), .gl = .{
-        .force_gles2 = sapp.gles2(),
-    }, .metal = .{
-        .device = sapp.sapp_metal_get_device(),
-        .renderpass_descriptor_cb = sapp.sapp_metal_get_renderpass_descriptor,
-        .drawable_cb = sapp.sapp_metal_get_drawable,
-    }, .d3d11 = .{ .device = sapp.sapp_d3d11_get_device(), .device_context = sapp.sapp_d3d11_get_device_context(), .render_target_view_cb = sapp.sapp_d3d11_get_render_target_view, .depth_stencil_view_cb = sapp.sapp_d3d11_get_depth_stencil_view }, .wgpu = .{ .device = sapp.sapp_wgpu_get_device(), .render_view_cb = sapp.sapp_wgpu_get_render_view, .resolve_view_cb = sapp.sapp_wgpu_get_resolve_view, .depth_stencil_view_cb = sapp.sapp_wgpu_get_depth_stencil_view } };
+    return sg.ContextDesc{
+        .color_format = sapp.colorFormat(),
+        .depth_format = sapp.depthFormat(),
+        .sample_count = sapp.sampleCount(),
+        .gl = .{
+            .force_gles2 = sapp.gles2(),
+        },
+        .metal = .{
+            .device = sapp.sapp_metal_get_device(),
+            .renderpass_descriptor_cb = sapp.sapp_metal_get_renderpass_descriptor,
+            .drawable_cb = sapp.sapp_metal_get_drawable,
+        },
+        .d3d11 = .{
+            .device = sapp.sapp_d3d11_get_device(),
+            .device_context = sapp.sapp_d3d11_get_device_context(),
+            .render_target_view_cb = sapp.sapp_d3d11_get_render_target_view,
+            .depth_stencil_view_cb = sapp.sapp_d3d11_get_depth_stencil_view,
+        },
+        .wgpu = .{
+            .device = sapp.sapp_wgpu_get_device(),
+            .render_view_cb = sapp.sapp_wgpu_get_render_view,
+            .resolve_view_cb = sapp.sapp_wgpu_get_resolve_view,
+            .depth_stencil_view_cb = sapp.sapp_wgpu_get_depth_stencil_view,
+        },
+    };
 }

--- a/src/sokol/app_gfx_glue.zig
+++ b/src/sokol/app_gfx_glue.zig
@@ -2,32 +2,11 @@ const sg = @import("gfx.zig");
 const sapp = @import("app.zig");
 
 pub fn context() sg.ContextDesc {
-    return sg.ContextDesc {
-        .color_format = sapp.colorFormat(),
-        .depth_format = sapp.depthFormat(),
-        .sample_count = sapp.sampleCount(),
-        .gl = .{
-            .force_gles2 = sapp.gles2(),
-        },
-        .metal = .{
-            .device = sapp.sapp_metal_get_device(),
-            .renderpass_descriptor_cb = sapp.sapp_metal_get_renderpass_descriptor,
-            .drawable_cb = sapp.sapp_metal_get_drawable,
-        },
-        .d3d11 = .{
-            .device = sapp.sapp_d3d11_get_device(),
-            .device_context = sapp.sapp_d3d11_get_device_context(),
-            .render_target_view_cb = sapp.sapp_d3d11_get_render_target_view,
-            .depth_stencil_view_cb = sapp.sapp_d3d11_get_depth_stencil_view
-        },
-        .wgpu = .{
-            .device = sapp.sapp_wgpu_get_device(),
-            .render_view_cb = sapp.sapp_wgpu_get_render_view,
-            .resolve_view_cb = sapp.sapp_wgpu_get_resolve_view,
-            .depth_stencil_view_cb = sapp.sapp_wgpu_get_depth_stencil_view
-        }
-    };
+    return sg.ContextDesc{ .color_format = sapp.colorFormat(), .depth_format = sapp.depthFormat(), .sample_count = sapp.sampleCount(), .gl = .{
+        .force_gles2 = sapp.gles2(),
+    }, .metal = .{
+        .device = sapp.sapp_metal_get_device(),
+        .renderpass_descriptor_cb = sapp.sapp_metal_get_renderpass_descriptor,
+        .drawable_cb = sapp.sapp_metal_get_drawable,
+    }, .d3d11 = .{ .device = sapp.sapp_d3d11_get_device(), .device_context = sapp.sapp_d3d11_get_device_context(), .render_target_view_cb = sapp.sapp_d3d11_get_render_target_view, .depth_stencil_view_cb = sapp.sapp_d3d11_get_depth_stencil_view }, .wgpu = .{ .device = sapp.sapp_wgpu_get_device(), .render_view_cb = sapp.sapp_wgpu_get_render_view, .resolve_view_cb = sapp.sapp_wgpu_get_resolve_view, .depth_stencil_view_cb = sapp.sapp_wgpu_get_depth_stencil_view } };
 }
-
-
-

--- a/src/sokol/audio.zig
+++ b/src/sokol/audio.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 pub const LogItem = enum(i32) {
     OK,
@@ -45,12 +45,12 @@ pub const LogItem = enum(i32) {
     BACKEND_BUFFER_SIZE_ISNT_MULTIPLE_OF_PACKET_SIZE,
 };
 pub const Logger = extern struct {
-    func: ?*const fn([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
+    func: ?*const fn ([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Allocator = extern struct {
-    alloc: ?*const fn(usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
-    free: ?*const fn(?*anyopaque, ?*anyopaque) callconv(.C) void = null,
+    alloc: ?*const fn (usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
+    free: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Desc = extern struct {
@@ -59,11 +59,11 @@ pub const Desc = extern struct {
     buffer_frames: i32 = 0,
     packet_frames: i32 = 0,
     num_packets: i32 = 0,
-    stream_cb: ?*const fn([*c] f32, i32, i32) callconv(.C) void = null,
-    stream_userdata_cb: ?*const fn([*c] f32, i32, i32, ?*anyopaque) callconv(.C) void = null,
+    stream_cb: ?*const fn ([*c]f32, i32, i32) callconv(.C) void = null,
+    stream_userdata_cb: ?*const fn ([*c]f32, i32, i32, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
-    allocator: Allocator = .{ },
-    logger: Logger = .{ },
+    allocator: Allocator = .{},
+    logger: Logger = .{},
 };
 pub extern fn saudio_setup([*c]const Desc) void;
 pub fn setup(desc: Desc) void {

--- a/src/sokol/debugtext.zig
+++ b/src/sokol/debugtext.zig
@@ -5,7 +5,7 @@ const sg = @import("gfx.zig");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 // helper function to convert "anything" to a Range struct
 pub fn asRange(val: anytype) Range {
@@ -23,13 +23,13 @@ pub fn asRange(val: anytype) Range {
         },
         else => {
             @compileError("Cannot convert to range!");
-        }
+        },
     }
 }
 
 // std.fmt compatible Writer
 pub const Writer = struct {
-    pub const Error = error { };
+    pub const Error = error{};
     pub fn writeAll(self: Writer, bytes: []const u8) Error!void {
         _ = self;
         for (bytes) |byte| {
@@ -39,7 +39,7 @@ pub const Writer = struct {
     pub fn writeByteNTimes(self: Writer, byte: u8, n: u64) Error!void {
         _ = self;
         var i: u64 = 0;
-        while (i < n): (i += 1) {
+        while (i < n) : (i += 1) {
             putc(byte);
         }
     }
@@ -59,7 +59,7 @@ pub const LogItem = enum(i32) {
     CANNOT_DESTROY_DEFAULT_CONTEXT,
 };
 pub const Logger = extern struct {
-    func: ?*const fn([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
+    func: ?*const fn ([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Context = extern struct {
@@ -70,7 +70,7 @@ pub const Range = extern struct {
     size: usize = 0,
 };
 pub const FontDesc = extern struct {
-    data: Range = .{ },
+    data: Range = .{},
     first_char: u8 = 0,
     last_char: u8 = 0,
 };
@@ -85,17 +85,17 @@ pub const ContextDesc = extern struct {
     sample_count: i32 = 0,
 };
 pub const Allocator = extern struct {
-    alloc: ?*const fn(usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
-    free: ?*const fn(?*anyopaque, ?*anyopaque) callconv(.C) void = null,
+    alloc: ?*const fn (usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
+    free: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Desc = extern struct {
     context_pool_size: i32 = 0,
     printf_buf_size: i32 = 0,
     fonts: [8]FontDesc = [_]FontDesc{.{}} ** 8,
-    context: ContextDesc = .{ },
-    allocator: Allocator = .{ },
-    logger: Logger = .{ },
+    context: ContextDesc = .{},
+    allocator: Allocator = .{},
+    logger: Logger = .{},
 };
 pub extern fn sdtx_setup([*c]const Desc) void;
 pub fn setup(desc: Desc) void {
@@ -239,9 +239,9 @@ pub fn putc(c: u8) void {
 }
 pub extern fn sdtx_puts([*c]const u8) void;
 pub fn puts(str: [:0]const u8) void {
-    sdtx_puts(@ptrCast([*c]const u8,str));
+    sdtx_puts(@as([*c]const u8, @ptrCast(str)));
 }
 pub extern fn sdtx_putr([*c]const u8, i32) void;
 pub fn putr(str: [:0]const u8, len: i32) void {
-    sdtx_putr(@ptrCast([*c]const u8,str), len);
+    sdtx_putr(@as([*c]const u8, @ptrCast(str)), len);
 }

--- a/src/sokol/gfx.zig
+++ b/src/sokol/gfx.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 // helper function to convert "anything" to a Range struct
 pub fn asRange(val: anytype) Range {
@@ -22,7 +22,7 @@ pub fn asRange(val: anytype) Range {
         },
         else => {
             @compileError("Cannot convert to range!");
-        }
+        },
     }
 }
 
@@ -399,7 +399,7 @@ pub const Action = enum(i32) {
 };
 pub const ColorAttachmentAction = extern struct {
     action: Action = .DEFAULT,
-    value: Color = .{ },
+    value: Color = .{},
 };
 pub const DepthAttachmentAction = extern struct {
     action: Action = .DEFAULT,
@@ -412,15 +412,15 @@ pub const StencilAttachmentAction = extern struct {
 pub const PassAction = extern struct {
     _start_canary: u32 = 0,
     colors: [4]ColorAttachmentAction = [_]ColorAttachmentAction{.{}} ** 4,
-    depth: DepthAttachmentAction = .{ },
-    stencil: StencilAttachmentAction = .{ },
+    depth: DepthAttachmentAction = .{},
+    stencil: StencilAttachmentAction = .{},
     _end_canary: u32 = 0,
 };
 pub const Bindings = extern struct {
     _start_canary: u32 = 0,
     vertex_buffers: [8]Buffer = [_]Buffer{.{}} ** 8,
     vertex_buffer_offsets: [8]i32 = [_]i32{0} ** 8,
-    index_buffer: Buffer = .{ },
+    index_buffer: Buffer = .{},
     index_buffer_offset: i32 = 0,
     vs_images: [12]Image = [_]Image{.{}} ** 12,
     fs_images: [12]Image = [_]Image{.{}} ** 12,
@@ -431,16 +431,16 @@ pub const BufferDesc = extern struct {
     size: usize = 0,
     type: BufferType = .DEFAULT,
     usage: Usage = .DEFAULT,
-    data: Range = .{ },
+    data: Range = .{},
     label: [*c]const u8 = null,
     gl_buffers: [2]u32 = [_]u32{0} ** 2,
-    mtl_buffers: [2]?*const anyopaque = [_]?*const anyopaque { null } ** 2,
+    mtl_buffers: [2]?*const anyopaque = [_]?*const anyopaque{null} ** 2,
     d3d11_buffer: ?*const anyopaque = null,
     wgpu_buffer: ?*const anyopaque = null,
     _end_canary: u32 = 0,
 };
 pub const ImageData = extern struct {
-    subimage: [6][16]Range = [_][16]Range{[_]Range{ .{ } }**16}**6,
+    subimage: [6][16]Range = [_][16]Range{[_]Range{.{}} ** 16} ** 6,
 };
 pub const ImageDesc = extern struct {
     _start_canary: u32 = 0,
@@ -462,11 +462,11 @@ pub const ImageDesc = extern struct {
     max_anisotropy: u32 = 0,
     min_lod: f32 = 0.0,
     max_lod: f32 = 0.0,
-    data: ImageData = .{ },
+    data: ImageData = .{},
     label: [*c]const u8 = null,
     gl_textures: [2]u32 = [_]u32{0} ** 2,
     gl_texture_target: u32 = 0,
-    mtl_textures: [2]?*const anyopaque = [_]?*const anyopaque { null } ** 2,
+    mtl_textures: [2]?*const anyopaque = [_]?*const anyopaque{null} ** 2,
     d3d11_texture: ?*const anyopaque = null,
     d3d11_shader_resource_view: ?*const anyopaque = null,
     wgpu_texture: ?*const anyopaque = null,
@@ -494,7 +494,7 @@ pub const ShaderImageDesc = extern struct {
 };
 pub const ShaderStageDesc = extern struct {
     source: [*c]const u8 = null,
-    bytecode: Range = .{ },
+    bytecode: Range = .{},
     entry: [*c]const u8 = null,
     d3d11_target: [*c]const u8 = null,
     uniform_blocks: [4]ShaderUniformBlockDesc = [_]ShaderUniformBlockDesc{.{}} ** 4,
@@ -503,8 +503,8 @@ pub const ShaderStageDesc = extern struct {
 pub const ShaderDesc = extern struct {
     _start_canary: u32 = 0,
     attrs: [16]ShaderAttrDesc = [_]ShaderAttrDesc{.{}} ** 16,
-    vs: ShaderStageDesc = .{ },
-    fs: ShaderStageDesc = .{ },
+    vs: ShaderStageDesc = .{},
+    fs: ShaderStageDesc = .{},
     label: [*c]const u8 = null,
     _end_canary: u32 = 0,
 };
@@ -532,8 +532,8 @@ pub const StencilFaceState = extern struct {
 };
 pub const StencilState = extern struct {
     enabled: bool = false,
-    front: StencilFaceState = .{ },
-    back: StencilFaceState = .{ },
+    front: StencilFaceState = .{},
+    back: StencilFaceState = .{},
     read_mask: u8 = 0,
     write_mask: u8 = 0,
     ref: u8 = 0,
@@ -558,14 +558,14 @@ pub const BlendState = extern struct {
 pub const ColorState = extern struct {
     pixel_format: PixelFormat = .DEFAULT,
     write_mask: ColorMask = .DEFAULT,
-    blend: BlendState = .{ },
+    blend: BlendState = .{},
 };
 pub const PipelineDesc = extern struct {
     _start_canary: u32 = 0,
-    shader: Shader = .{ },
-    layout: LayoutDesc = .{ },
-    depth: DepthState = .{ },
-    stencil: StencilState = .{ },
+    shader: Shader = .{},
+    layout: LayoutDesc = .{},
+    depth: DepthState = .{},
+    stencil: StencilState = .{},
     color_count: i32 = 0,
     colors: [4]ColorState = [_]ColorState{.{}} ** 4,
     primitive_type: PrimitiveType = .DEFAULT,
@@ -573,20 +573,20 @@ pub const PipelineDesc = extern struct {
     cull_mode: CullMode = .DEFAULT,
     face_winding: FaceWinding = .DEFAULT,
     sample_count: i32 = 0,
-    blend_color: Color = .{ },
+    blend_color: Color = .{},
     alpha_to_coverage_enabled: bool = false,
     label: [*c]const u8 = null,
     _end_canary: u32 = 0,
 };
 pub const PassAttachmentDesc = extern struct {
-    image: Image = .{ },
+    image: Image = .{},
     mip_level: i32 = 0,
     slice: i32 = 0,
 };
 pub const PassDesc = extern struct {
     _start_canary: u32 = 0,
     color_attachments: [4]PassAttachmentDesc = [_]PassAttachmentDesc{.{}} ** 4,
-    depth_stencil_attachment: PassAttachmentDesc = .{ },
+    depth_stencil_attachment: PassAttachmentDesc = .{},
     label: [*c]const u8 = null,
     _end_canary: u32 = 0,
 };
@@ -596,7 +596,7 @@ pub const SlotInfo = extern struct {
     ctx_id: u32 = 0,
 };
 pub const BufferInfo = extern struct {
-    slot: SlotInfo = .{ },
+    slot: SlotInfo = .{},
     update_frame_index: u32 = 0,
     append_frame_index: u32 = 0,
     append_pos: i32 = 0,
@@ -605,19 +605,19 @@ pub const BufferInfo = extern struct {
     active_slot: i32 = 0,
 };
 pub const ImageInfo = extern struct {
-    slot: SlotInfo = .{ },
+    slot: SlotInfo = .{},
     upd_frame_index: u32 = 0,
     num_slots: i32 = 0,
     active_slot: i32 = 0,
 };
 pub const ShaderInfo = extern struct {
-    slot: SlotInfo = .{ },
+    slot: SlotInfo = .{},
 };
 pub const PipelineInfo = extern struct {
-    slot: SlotInfo = .{ },
+    slot: SlotInfo = .{},
 };
 pub const PassInfo = extern struct {
-    slot: SlotInfo = .{ },
+    slot: SlotInfo = .{},
 };
 pub const LogItem = enum(i32) {
     OK,
@@ -804,51 +804,51 @@ pub const GlContextDesc = extern struct {
 };
 pub const MetalContextDesc = extern struct {
     device: ?*const anyopaque = null,
-    renderpass_descriptor_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    renderpass_descriptor_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
-    drawable_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    drawable_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    renderpass_descriptor_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    renderpass_descriptor_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    drawable_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    drawable_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
     user_data: ?*anyopaque = null,
 };
 pub const D3d11ContextDesc = extern struct {
     device: ?*const anyopaque = null,
     device_context: ?*const anyopaque = null,
-    render_target_view_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    render_target_view_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
-    depth_stencil_view_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    depth_stencil_view_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    render_target_view_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    render_target_view_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    depth_stencil_view_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    depth_stencil_view_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
     user_data: ?*anyopaque = null,
 };
 pub const WgpuContextDesc = extern struct {
     device: ?*const anyopaque = null,
-    render_view_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    render_view_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
-    resolve_view_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    resolve_view_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
-    depth_stencil_view_cb: ?*const fn() callconv(.C) ?*const anyopaque = null,
-    depth_stencil_view_userdata_cb: ?*const fn(?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    render_view_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    render_view_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    resolve_view_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    resolve_view_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
+    depth_stencil_view_cb: ?*const fn () callconv(.C) ?*const anyopaque = null,
+    depth_stencil_view_userdata_cb: ?*const fn (?*anyopaque) callconv(.C) ?*const anyopaque = null,
     user_data: ?*anyopaque = null,
 };
 pub const ContextDesc = extern struct {
     color_format: i32 = 0,
     depth_format: i32 = 0,
     sample_count: i32 = 0,
-    gl: GlContextDesc = .{ },
-    metal: MetalContextDesc = .{ },
-    d3d11: D3d11ContextDesc = .{ },
-    wgpu: WgpuContextDesc = .{ },
+    gl: GlContextDesc = .{},
+    metal: MetalContextDesc = .{},
+    d3d11: D3d11ContextDesc = .{},
+    wgpu: WgpuContextDesc = .{},
 };
 pub const CommitListener = extern struct {
-    func: ?*const fn(?*anyopaque) callconv(.C) void = null,
+    func: ?*const fn (?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Allocator = extern struct {
-    alloc: ?*const fn(usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
-    free: ?*const fn(?*anyopaque, ?*anyopaque) callconv(.C) void = null,
+    alloc: ?*const fn (usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
+    free: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Logger = extern struct {
-    func: ?*const fn([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
+    func: ?*const fn ([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Desc = extern struct {
@@ -864,9 +864,9 @@ pub const Desc = extern struct {
     sampler_cache_size: i32 = 0,
     max_commit_listeners: i32 = 0,
     disable_validation: bool = false,
-    allocator: Allocator = .{ },
-    logger: Logger = .{ },
-    context: ContextDesc = .{ },
+    allocator: Allocator = .{},
+    logger: Logger = .{},
+    context: ContextDesc = .{},
     _end_canary: u32 = 0,
 };
 pub extern fn sg_setup([*c]const Desc) void;
@@ -887,7 +887,7 @@ pub fn resetStateCache() void {
 }
 pub extern fn sg_push_debug_group([*c]const u8) void;
 pub fn pushDebugGroup(name: [:0]const u8) void {
-    sg_push_debug_group(@ptrCast([*c]const u8,name));
+    sg_push_debug_group(@as([*c]const u8, @ptrCast(name)));
 }
 pub extern fn sg_pop_debug_group() void;
 pub fn popDebugGroup() void {

--- a/src/sokol/gl.zig
+++ b/src/sokol/gl.zig
@@ -5,7 +5,7 @@ const sg = @import("gfx.zig");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 pub const LogItem = enum(i32) {
     OK,
@@ -17,7 +17,7 @@ pub const LogItem = enum(i32) {
     CANNOT_DESTROY_DEFAULT_CONTEXT,
 };
 pub const Logger = extern struct {
-    func: ?*const fn([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
+    func: ?*const fn ([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Pipeline = extern struct {
@@ -43,8 +43,8 @@ pub const ContextDesc = extern struct {
     sample_count: i32 = 0,
 };
 pub const Allocator = extern struct {
-    alloc: ?*const fn(usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
-    free: ?*const fn(?*anyopaque, ?*anyopaque) callconv(.C) void = null,
+    alloc: ?*const fn (usize, ?*anyopaque) callconv(.C) ?*anyopaque = null,
+    free: ?*const fn (?*anyopaque, ?*anyopaque) callconv(.C) void = null,
     user_data: ?*anyopaque = null,
 };
 pub const Desc = extern struct {
@@ -56,8 +56,8 @@ pub const Desc = extern struct {
     depth_format: sg.PixelFormat = .DEFAULT,
     sample_count: i32 = 0,
     face_winding: sg.FaceWinding = .DEFAULT,
-    allocator: Allocator = .{ },
-    logger: Logger = .{ },
+    allocator: Allocator = .{},
+    logger: Logger = .{},
 };
 pub extern fn sgl_setup([*c]const Desc) void;
 pub fn setup(desc: Desc) void {

--- a/src/sokol/log.zig
+++ b/src/sokol/log.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 pub extern fn slog_func([*c]const u8, u32, u32, [*c]const u8, u32, [*c]const u8, ?*anyopaque) void;
 pub const func = slog_func;

--- a/src/sokol/shape.zig
+++ b/src/sokol/shape.zig
@@ -5,7 +5,7 @@ const sg = @import("gfx.zig");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 // helper function to convert "anything" to a Range struct
 pub fn asRange(val: anytype) Range {
@@ -23,7 +23,7 @@ pub fn asRange(val: anytype) Range {
         },
         else => {
             @compileError("Cannot convert to range!");
-        }
+        },
     }
 }
 
@@ -32,7 +32,7 @@ pub const Range = extern struct {
     size: usize = 0,
 };
 pub const Mat4 = extern struct {
-    m: [4][4]f32 = [_][4]f32{[_]f32{ 0.0 }**4}**4,
+    m: [4][4]f32 = [_][4]f32{[_]f32{0.0} ** 4} ** 4,
 };
 pub const Vertex = extern struct {
     x: f32 = 0.0,
@@ -54,18 +54,18 @@ pub const SizesItem = extern struct {
     __pad: [3]u32 = [_]u32{0} ** 3,
 };
 pub const Sizes = extern struct {
-    vertices: SizesItem = .{ },
-    indices: SizesItem = .{ },
+    vertices: SizesItem = .{},
+    indices: SizesItem = .{},
 };
 pub const BufferItem = extern struct {
-    buffer: Range = .{ },
+    buffer: Range = .{},
     data_size: usize = 0,
     shape_offset: usize = 0,
 };
 pub const Buffer = extern struct {
     valid: bool = false,
-    vertices: BufferItem = .{ },
-    indices: BufferItem = .{ },
+    vertices: BufferItem = .{},
+    indices: BufferItem = .{},
 };
 pub const Plane = extern struct {
     width: f32 = 0.0,
@@ -74,7 +74,7 @@ pub const Plane = extern struct {
     color: u32 = 0,
     random_colors: bool = false,
     merge: bool = false,
-    transform: Mat4 = .{ },
+    transform: Mat4 = .{},
 };
 pub const Box = extern struct {
     width: f32 = 0.0,
@@ -84,7 +84,7 @@ pub const Box = extern struct {
     color: u32 = 0,
     random_colors: bool = false,
     merge: bool = false,
-    transform: Mat4 = .{ },
+    transform: Mat4 = .{},
 };
 pub const Sphere = extern struct {
     radius: f32 = 0.0,
@@ -93,7 +93,7 @@ pub const Sphere = extern struct {
     color: u32 = 0,
     random_colors: bool = false,
     merge: bool = false,
-    transform: Mat4 = .{ },
+    transform: Mat4 = .{},
 };
 pub const Cylinder = extern struct {
     radius: f32 = 0.0,
@@ -103,7 +103,7 @@ pub const Cylinder = extern struct {
     color: u32 = 0,
     random_colors: bool = false,
     merge: bool = false,
-    transform: Mat4 = .{ },
+    transform: Mat4 = .{},
 };
 pub const Torus = extern struct {
     radius: f32 = 0.0,
@@ -113,7 +113,7 @@ pub const Torus = extern struct {
     color: u32 = 0,
     random_colors: bool = false,
     merge: bool = false,
-    transform: Mat4 = .{ },
+    transform: Mat4 = .{},
 };
 pub extern fn sshape_build_plane([*c]const Buffer, [*c]const Plane) Buffer;
 pub fn buildPlane(buf: Buffer, params: Plane) Buffer {

--- a/src/sokol/time.zig
+++ b/src/sokol/time.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 // helper function to convert a C string to a Zig string slice
 fn cStrToZig(c_str: [*c]const u8) [:0]const u8 {
-  return @import("std").mem.span(c_str);
+    return @import("std").mem.span(c_str);
 }
 pub extern fn stm_setup() void;
 pub fn setup() void {
@@ -22,8 +22,8 @@ pub extern fn stm_since(u64) u64;
 pub fn since(start_ticks: u64) u64 {
     return stm_since(start_ticks);
 }
-pub extern fn stm_laptime([*c] u64) u64;
-pub fn laptime(last_time: * u64) u64 {
+pub extern fn stm_laptime([*c]u64) u64;
+pub fn laptime(last_time: *u64) u64 {
     return stm_laptime(last_time);
 }
 pub extern fn stm_round_to_common_refresh_rate(u64) u64;


### PR DESCRIPTION
New change from the latest zig version uses `@destFromSrc()` instead of `@srcToDest()` for casting