### PR TITLE
When building for darwin, differentiate between iOS and macOS frameworks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,14 +68,20 @@ pub fn buildSokol(b: *Builder, target: CrossTarget, optimize: OptimizeMode, conf
                 .flags = &[_][]const u8{ "-ObjC", "-DIMPL", backend_option },
             });
         }
-        lib.linkFramework("Cocoa");
-        lib.linkFramework("QuartzCore");
         lib.linkFramework("AudioToolbox");
         if (.metal == _backend) {
             lib.linkFramework("MetalKit");
             lib.linkFramework("Metal");
         } else {
             lib.linkFramework("OpenGL");
+        }
+        if (target.getOsTag() == .ios) {
+            lib.linkFramework("UIKit");
+            lib.linkFramework("AVFoundation");
+            lib.linkFramework("Foundation");
+        } else {
+            lib.linkFramework("Cocoa");
+            lib.linkFramework("QuartzCore");
         }
     } else {
         var egl_flag = if (config.force_egl) "-DSOKOL_FORCE_EGL " else "";

--- a/build.zig
+++ b/build.zig
@@ -68,20 +68,25 @@ pub fn buildSokol(b: *Builder, target: CrossTarget, optimize: OptimizeMode, conf
                 .flags = &[_][]const u8{ "-ObjC", "-DIMPL", backend_option },
             });
         }
+        lib.linkFramework("Foundation");
         lib.linkFramework("AudioToolbox");
         if (.metal == _backend) {
             lib.linkFramework("MetalKit");
             lib.linkFramework("Metal");
-        } else {
-            lib.linkFramework("OpenGL");
         }
-        if (target.getOsTag() == .ios) {
+        if (lib.target.getOsTag() == .ios) {
             lib.linkFramework("UIKit");
             lib.linkFramework("AVFoundation");
-            lib.linkFramework("Foundation");
-        } else {
+            if (.gl == _backend) {
+                lib.linkFramework("OpenGLES");
+                lib.linkFramework("GLKit");
+            }
+        } else if (lib.target.getOsTag() == .macos) {
             lib.linkFramework("Cocoa");
             lib.linkFramework("QuartzCore");
+            if (.gl == _backend) {
+                lib.linkFramework("OpenGL");
+            }
         }
     } else {
         var egl_flag = if (config.force_egl) "-DSOKOL_FORCE_EGL " else "";


### PR DESCRIPTION
When trying to use sokol-zig with an iOS target, Cocoa and QuartzCore frameworks are incorrectly included during linking. This change aims to make it such that only correct frameworks are linked depending on the target.

Referenced [libSokol in pacman.zig](https://github.com/floooh/pacman.zig/blob/main/build.zig#L136) to make this PR.