### PR TITLE
wasm support and zig-0.12.0 fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: 0.11.0
       - name: prepare-linux
         if: runner.os == 'Linux'
         run: |
             sudo apt-get update
             sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev
-      - name: build
-        run: zig build
+      - name: build Native
+        run: zig build --summary all
+      - name: build Wasm
+        run: zig build --summary all -Dtarget=wasm32-emscripten

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = "sokol-zig",
+    .version = "0.0.0",
+    .minimum_zig_version = "0.12.0",
+    .dependencies = .{
+        .emsdk = .{
+            .url = "git+https://github.com/emscripten-core/emsdk#0bbae74935d57ff41739648c12cf90b56668398f",
+            .hash = "1220f1340cd871b444021c600661f921f96091ce0815fa43008528f4844cece7e245",
+        },
+    },
+    .paths = .{""},
+}


### PR DESCRIPTION
## Tested
- OS: Linux (archlinux)
- Arch: x86_64 (zen3)
- zig version: `0.12.0-dev.2150+63de8a598`

### Steps

- zig get emsdk using `zon` file.
- run emsdk (download, extracts files)
- build libsokol w/ emscripten (os-tag)
- in examples run `emcc` and `emrun`

**Note:** This is experimental, and some examples get black screen on browser or get errors!!

### Reference
- https://github.com/floooh/sokol-zig/issues/8#issuecomment-1877562076