### PR TITLE
add SAFE_HEAP=1 and STACK_OVERFLOW_CHECK=1 for Emscripten Debug builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -301,6 +301,8 @@ pub fn emLinkStep(b: *Build, options: EmLinkOptions) !*Build.Step.Run {
     try emcc_cmd.append(emcc_path);
     if (options.optimize == .Debug) {
         try emcc_cmd.append("-Og");
+        try emcc_cmd.append("-sSAFE_HEAP=1");
+        try emcc_cmd.append("-sSTACK_OVERFLOW_CHECK=1");
     } else {
         try emcc_cmd.append("-sASSERTIONS=0");
         if (options.optimize == .ReleaseSmall) {


### PR DESCRIPTION
I've found adding these has helped me debug and actually understand why my Emscripten application was randomly crashing.

For example, I was loading an image with the Zigimg package and the errors in my Chrome/Firefox DevTools would just say segmentation fault without pointing at a clear reason for the crash.

With `-sSTACK_OVERFLOW_CHECK=1`, I was able to instead get the following message and realize that I needed to bump my stack size.
```
index.js:9219 Stack overflow detected.  You can try increasing -sSTACK_SIZE (currently set to 65536)
```