### PR TITLE
changed egl to EGL

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -239,7 +239,7 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*Build.Step.Compile {
             lib.linkSystemLibrary("xkbcommon");
         }
         if (link_egl) {
-            lib.linkSystemLibrary("egl");
+            lib.linkSystemLibrary("EGL");
         }
     } else if (lib.rootModuleTarget().os.tag == .windows) {
         lib.linkSystemLibrary("kernel32");


### PR DESCRIPTION
i noticed that when I was trying to build for wayland, the linker was looking for `libegl.so`, but my system only had `libEGL.so`.

THEN, i noticed that android builds look for `libEGL` and not `libegl`, so I figure the latter must be a typo.