### PR TITLE
Don't use system emcc

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -309,7 +309,7 @@ pub const EmLinkOptions = struct {
     extra_args: []const []const u8 = &.{},
 };
 pub fn emLinkStep(b: *Build, options: EmLinkOptions) !*Build.Step.InstallDir {
-    const emcc_path = b.findProgram(&.{"emcc"}, &.{}) catch emSdkLazyPath(b, options.emsdk, &.{ "upstream", "emscripten", "emcc" }).getPath(b);
+    const emcc_path = emSdkLazyPath(b, options.emsdk, &.{ "upstream", "emscripten", "emcc" }).getPath(b);
     const emcc = b.addSystemCommand(&.{emcc_path});
     emcc.setName("emcc"); // hide emcc path
     if (options.optimize == .Debug) {


### PR DESCRIPTION
Mixing system emcc with the versioned SDK from this package can cause mismatches in memory layouts, resulting in errors and crashes.

I discovered this because none of the demos here were working for me. They all saw GL errors when initializing `sokol-gfx`. It looked like the context attributes were corrupted between where they were written in `_sapp_emsc_webgl_init` and where they were read in `_emscripten_webgl_do_create_context` - the requested context major version was 0. It looked like an issue with struct layout: on the JS side, `renderViaOffscreenBackBuffer` looked like it was read as 2, which was certainly suspicious.

Syncing my system Emscripten version with the package version seemed to solve the issue, although it was always hard to be 100% sure I've cleared out all relevant build caches correctly. (Hardcoding the GL major version to 2 in JS also worked, but was a lot less informative.)

This change removes the most obvious source of cross-contamination I could find: it avoids using system emcc entirely. I seem to be getting successful builds now, but it might be worth testing this yourself.