### PR TITLE
Add use_gles3 option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,12 +14,13 @@ pub const SokolBackend = enum {
 
 pub fn build(b: *Build) !void {
     const opt_use_gl = b.option(bool, "gl", "Force OpenGL (default: false)") orelse false;
+    const opt_use_gles3 = b.option(bool, "gles3", "Force OpenGL ES3 (default: false)") orelse false;
     const opt_use_wgpu = b.option(bool, "wgpu", "Force WebGPU (default: false, web only)") orelse false;
     const opt_use_x11 = b.option(bool, "x11", "Force X11 (default: true, Linux only)") orelse true;
     const opt_use_wayland = b.option(bool, "wayland", "Force Wayland (default: false, Linux only, not supported in main-line headers)") orelse false;
     const opt_use_egl = b.option(bool, "egl", "Force EGL (default: false, Linux only)") orelse false;
     const opt_with_sokol_imgui = b.option(bool, "with_sokol_imgui", "Add support for sokol_imgui.h bindings") orelse false;
-    const sokol_backend: SokolBackend = if (opt_use_gl) .gl else if (opt_use_wgpu) .wgpu else .auto;
+    const sokol_backend: SokolBackend = if (opt_use_gl) .gl else if (opt_use_gles3) .gles3 else if (opt_use_wgpu) .wgpu else .auto;
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});


### PR DESCRIPTION
I had some trouble getting my sokol-zig-based project to run on my AArch64 Chromebook - and the sokol-zig examples as well. Turned out the solution was to force ES3, turn on EGL, and turn off MSAA. This change adds an option to force ES3, since I couldn't currently find another way to do that.

Not sure if there are reasons that ES3 should imply EGL or anything like that, so I figure I should probably make the minimal change that fixes my problem? But if something different would be better let me know.