### PR TITLE
Add NDEBUG flag to non-debug builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -209,6 +209,9 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*Build.Step.Compile {
     // resolve .auto backend into specific backend by platform
     var cflags = try std.BoundedArray([]const u8, 64).init(0);
     try cflags.append("-DIMPL");
+    if (options.optimize != .Debug) {
+        try cflags.append("-DNDEBUG");
+    }
     const backend = resolveSokolBackend(options.backend, lib.rootModuleTarget());
     switch (backend) {
         .d3d11 => try cflags.append("-DSOKOL_D3D11"),


### PR DESCRIPTION
I noticed that the performance of web builds was terrible due to a lot of calls to glGetError, which as far as I can tell shouldn't be called in release builds at all. Turns out `SOKOL_DEBUG` is defined even when using `-Doptimize=ReleaseSafe`. I may be missing something obvious, but shouldn't `NDEBUG` be defined in this case? :eyes: 