### PR TITLE
chore: generate docs to host on GitHub pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches: docs # changed this to master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: mlugg/setup-zig@v1
+        with:
+            version: master
+      - run: zig build-lib src/sokol/sokol.zig -femit-docs
+      - name: Update pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${\{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,8 @@ jobs:
             version: master
       - run: zig build-lib src/sokol/sokol.zig -femit-docs
       - name: Update pages artifact
-        uses: actions/upload-pages-artifact@v1
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/
   deploy:
@@ -26,4 +27,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+docs
 zig-*/
 .zig-*/
 NUL


### PR DESCRIPTION
Need to change to [run on `master` push instead of docs](https://github.com/floooh/sokol-zig/pull/93/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR3).

Example output: https://tjk.github.io/sokol-zig/

The docs can obviously be improved if the zig generation produces slightly better doc comments, but that might not be wanted.