### PR TITLE
fix shader compilation on linux arm64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -490,7 +490,7 @@ fn buildShaders(b: *Build, target: Build.ResolvedTarget) void {
     };
     const optional_shdc: ?[:0]const u8 = comptime switch (builtin.os.tag) {
         .windows => "win32/sokol-shdc.exe",
-        .linux => "linux/sokol-shdc",
+        .linux => if (builtin.cpu.arch.isX86()) "linux/sokol-shdc" else "linux_arm64/sokol-shdc",
         .macos => if (builtin.cpu.arch.isX86()) "osx/sokol-shdc" else "osx_arm64/sokol-shdc",
         else => null,
     };


### PR DESCRIPTION
Hi, this is just quick fix to detect Linux arm64 for shader compilation. This works at least on Raspberry Pi. Is this ok to merge or do other systems need to be tested? Thank you!