### PR TITLE
Fix missing field initializer in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,16 +133,19 @@ pub fn build(b: *Build) !void {
         .target = target,
         .optimize = optimize,
     });
-   const hello = b.addExecutable(.{
+    const hello = b.addExecutable(.{
         .name = "hello",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/hello.zig"),
             .target = target,
             .optimize = optimize,
-            .imports = .{
-                .{ .name = "sokol", dep_sokol.module("sokol") },
-            }
-        },
+            .imports = &.{
+                .{
+                    .name = "sokol",
+                    .module = dep_sokol.module("sokol"),
+                },
+            },
+        }),
     });
     b.installArtifact(hello);
     const run = b.addRunArtifact(hello);


### PR DESCRIPTION
I tried to use the example code provided in the readme and got the following error on line 143: "Expected field initializer" **dep_sokol**