### PR TITLE
Zig 0.17.x fixes (LazyPath.getPath removal etc)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,11 @@ jobs:
       - name: prepare-linux
         if: runner.os == 'Linux'
         run: |
-            sudo apt-get update
-            sudo apt-get install xorg-dev libasound-dev
+          sudo apt-get update
+          sudo apt-get install xorg-dev libasound-dev
       - name: build Native
         run: zig build examples --summary all
       - name: build Wasm
-        run: zig build examples --summary all -Dtarget=wasm32-emscripten
+        run: |
+          zig build install-emsdk
+          zig build examples --summary all -Dtarget=wasm32-emscripten

--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ sokol-zig ➤ zig build -Dgl=true run-clear
 Backend: .sokol.gfx.Backend.GLCORE33
 ```
 
-For the web-samples, run:
+For the web-samples, first install a local Emscripten SDK into `./zig-pkg`:
 
+```sh
+zig build install-emsdk
+```
+
+...then build with `-Dtarget=wasm32-emscripten`
 ```sh
 zig build examples -Dtarget=wasm32-emscripten
 # or to build and run one of the samples
@@ -108,11 +113,8 @@ zig build run-clear -Dtarget=wasm32-emscripten
 ...
 ```
 
-When building with target `wasm32-emscripten` for the first time, the build script will
-install and activate the Emscripten SDK into the Zig package cache for the latest SDK
-version. There is currently no build system functionality to update or delete the Emscripten SDK
-after this first install. The current workaround is to simply delete the `zig-pkg` subdirectory
-(for zig-0.16.x - previous versions stored the emsdk in the global Zig cache instead).
+There is currently no build system functionality to update or delete the Emscripten SDK
+after this first install. The current workaround is to simply delete the `zig-pkg` subdirectory.
 
 Improving the Emscripten SDK integration with the Zig build system is planned for the future.
 

--- a/build.zig
+++ b/build.zig
@@ -426,7 +426,7 @@ pub const EmRunOptions = struct {
 pub fn emRunStep(b: *Build, options: EmRunOptions) *Build.Step.Run {
     const emrun_path = emTool(b, options.emsdk, "emrun");
     const emrun = b.addRunFile(emrun_path);
-    emrun.addArgs(&.{b.fmt("web/{s}.html", .{options.name})});
+    emrun.addFileArg(b.path(b.fmt("zig-out/web/{s}.html", .{options.name})));
     return emrun;
 }
 

--- a/build.zig
+++ b/build.zig
@@ -466,7 +466,7 @@ pub fn emTool(b: *Build, emsdk: *Build.Dependency, tool: []const u8) Build.LazyP
 
 fn createEmsdkStep(b: *Build, emsdk: *Build.Dependency) *Build.Step.Run {
     if (builtin.os.tag == .windows) {
-        return b.addAddRunFile(emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
+        return b.addRunFile(emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
     } else {
         const step = b.addSystemCommand(&.{"bash"});
         step.addFileArg(emSdkLazyPath(b, emsdk, &.{"emsdk"}));

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const Build = std.Build;
 const OptimizeMode = std.builtin.OptimizeMode;
 
 // re-export the shader compiler module for use by upstream projects
-//pub const shdc = @import("shdc");
+pub const shdc = @import("shdc");
 
 const examples = [_]Example{
     .{ .name = "clear" },
@@ -530,7 +530,7 @@ fn buildExample(b: *Build, example: Example, examples_step: *Build.Step, options
     });
 
     // optionally build shader
-    const opt_shd_step = null; // try buildExampleShader(b, example);
+    const opt_shd_step = try buildExampleShader(b, example);
 
     var run: *Build.Step.Run = undefined;
     if (!isPlatform(options.target.result, .web)) {
@@ -577,25 +577,25 @@ fn buildExample(b: *Build, example: Example, examples_step: *Build.Step, options
     b.step(b.fmt("run-{s}", .{example.name}), b.fmt("Run {s}", .{example.name})).dependOn(&run.step);
 }
 
-//fn buildExampleShader(b: *Build, example: Example) !?*Build.Step {
-//    if (!example.has_shader) {
-//        return null;
-//    }
-//    const shaders_dir = "examples/shaders/";
-//    return shdc.createSourceFile(b, .{
-//        .shdc_dep = b.dependency("shdc", .{}),
-//        .input = b.fmt("{s}{s}.glsl", .{ shaders_dir, example.name }),
-//        .output = b.fmt("{s}{s}.glsl.zig", .{ shaders_dir, example.name }),
-//        .slang = .{
-//            .glsl430 = example.needs_compute,
-//            .glsl410 = !example.needs_compute,
-//            .glsl310es = example.needs_compute,
-//            .glsl300es = !example.needs_compute,
-//            .metal_macos = true,
-//            .hlsl5 = true,
-//            .wgsl = true,
-//            .spirv_vk = true,
-//        },
-//        .reflection = true,
-//    });
-//}
+fn buildExampleShader(b: *Build, example: Example) !?*Build.Step {
+    if (!example.has_shader) {
+        return null;
+    }
+    const shaders_dir = "examples/shaders/";
+    return shdc.createSourceFile(b, .{
+        .shdc_dep = b.dependency("shdc", .{}),
+        .input = b.fmt("{s}{s}.glsl", .{ shaders_dir, example.name }),
+        .output = b.fmt("{s}{s}.glsl.zig", .{ shaders_dir, example.name }),
+        .slang = .{
+            .glsl430 = example.needs_compute,
+            .glsl410 = !example.needs_compute,
+            .glsl310es = example.needs_compute,
+            .glsl300es = !example.needs_compute,
+            .metal_macos = true,
+            .hlsl5 = true,
+            .wgsl = true,
+            .spirv_vk = true,
+        },
+        .reflection = true,
+    });
+}

--- a/build.zig
+++ b/build.zig
@@ -470,7 +470,8 @@ fn emSdkLazyPath(b: *Build, emsdk: *Build.Dependency, sub_paths: []const []const
 
 // helper function to get Emscripten SDK tool path
 pub fn emTool(b: *Build, emsdk: *Build.Dependency, tool: []const u8) Build.LazyPath {
-    return emSdkLazyPath(b, emsdk, &.{ "upstream", "emscripten", tool });
+    const toolFilename = if (builtin.os.tag == .windows) b.fmt("{s}.bat", .{tool}) else tool;
+    return emSdkLazyPath(b, emsdk, &.{ "upstream", "emscripten", toolFilename });
 }
 
 fn createEmsdkStep(b: *Build, emsdk: *Build.Dependency) *Build.Step.Run {

--- a/build.zig
+++ b/build.zig
@@ -340,6 +340,15 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*Build.Step.Compile {
     return lib;
 }
 
+// Zig 0.16.0 vs 0.17.0 compatibility helper
+fn addRunFile(b: *Build, p: Build.LazyPath) *Build.Step.Run {
+    if (builtin.zig_version.minor <= 16) {
+        return b.addSystemCommand(&.{p.getPath(b)});
+    } else {
+        return b.addRunFile(p);
+    }
+}
+
 //== EMSCRIPTEN INTEGRATION ============================================================================================
 
 // for wasm32-emscripten, need to run the Emscripten linker from the Emscripten SDK
@@ -360,7 +369,7 @@ pub const EmLinkOptions = struct {
 };
 pub fn emLinkStep(b: *Build, options: EmLinkOptions) !*Build.Step.InstallDir {
     const emcc_path = emTool(b, options.emsdk, "emcc");
-    const emcc = b.addRunFile(emcc_path);
+    const emcc = addRunFile(b, emcc_path);
     emcc.setName("emcc"); // hide emcc path
     if (options.optimize == .Debug) {
         emcc.addArgs(&.{ "-Og", "-sSAFE_HEAP=1", "-sSTACK_OVERFLOW_CHECK=1" });
@@ -425,7 +434,7 @@ pub const EmRunOptions = struct {
 };
 pub fn emRunStep(b: *Build, options: EmRunOptions) *Build.Step.Run {
     const emrun_path = emTool(b, options.emsdk, "emrun");
-    const emrun = b.addRunFile(emrun_path);
+    const emrun = addRunFile(b, emrun_path);
     emrun.addFileArg(b.path(b.fmt("zig-out/web/{s}.html", .{options.name})));
     return emrun;
 }
@@ -440,7 +449,7 @@ pub const EmBuilderOptions = struct {
 };
 pub fn emBuilderStep(b: *Build, options: EmBuilderOptions) *Build.Step.Run {
     const embuilder_path = emTool(b, options.emsdk, "embuilder");
-    const embuilder = b.addRunFile(embuilder_path);
+    const embuilder = addRunFile(b, embuilder_path);
     if (options.lto) {
         embuilder.addArg("--lto");
     }
@@ -466,7 +475,7 @@ pub fn emTool(b: *Build, emsdk: *Build.Dependency, tool: []const u8) Build.LazyP
 
 fn createEmsdkStep(b: *Build, emsdk: *Build.Dependency) *Build.Step.Run {
     if (builtin.os.tag == .windows) {
-        return b.addRunFile(emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
+        return addRunFile(b, emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
     } else {
         const step = b.addSystemCommand(&.{"bash"});
         step.addFileArg(emSdkLazyPath(b, emsdk, &.{"emsdk"}));

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const Build = std.Build;
 const OptimizeMode = std.builtin.OptimizeMode;
 
 // re-export the shader compiler module for use by upstream projects
-pub const shdc = @import("shdc");
+//pub const shdc = @import("shdc");
 
 const examples = [_]Example{
     .{ .name = "clear" },
@@ -81,6 +81,9 @@ pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const emsdk = b.dependency("emsdk", .{});
+
+    // add install-emsdk run step
+    emSdkAddInstallStep(b, emsdk);
 
     // a module for the actual bindings, and a static link library with the C code
     const mod_sokol = b.addModule("sokol", .{ .root_source_file = b.path("src/sokol/sokol.zig") });
@@ -180,24 +183,15 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*Build.Step.Compile {
             std.log.err("Please build with 'zig build -Dtarget=wasm32-emscripten", .{});
             return error.TargetWasm32EmscriptenExpected;
         }
-        const opt_emsdk_setup_step = try emSdkSetupStep(b, emsdk);
-
         // for WebGPU, need to run embuilder for `emdawnwebgpu` after emsdk setup and before C library build
         if (options.backend == .wgpu) {
             const embuilder_step = emBuilderStep(b, .{
                 .port_name = "emdawnwebgpu",
                 .emsdk = emsdk,
             });
-            if (opt_emsdk_setup_step) |emsdk_setup_step| {
-                embuilder_step.step.dependOn(&emsdk_setup_step.step);
-            }
             lib.step.dependOn(&embuilder_step.step);
             // need to add include path to find emdawnwebgpu <webgpu/webgpu.h> before Emscripten SDK webgpu.h
             mod.addSystemIncludePath(emSdkLazyPath(b, emsdk, &.{ "upstream", "emscripten", "cache", "ports", "emdawnwebgpu", "emdawnwebgpu_pkg", "webgpu", "include" }));
-        } else {
-            if (opt_emsdk_setup_step) |emsdk_setup_step| {
-                lib.step.dependOn(&emsdk_setup_step.step);
-            }
         }
 
         // add the Emscripten system include seach path
@@ -365,8 +359,8 @@ pub const EmLinkOptions = struct {
     extra_args: []const []const u8 = &.{},
 };
 pub fn emLinkStep(b: *Build, options: EmLinkOptions) !*Build.Step.InstallDir {
-    const emcc_path = emTool(b, options.emsdk, "emcc").getPath(b);
-    const emcc = b.addSystemCommand(&.{emcc_path});
+    const emcc_path = emTool(b, options.emsdk, "emcc");
+    const emcc = b.addRunFile(emcc_path);
     emcc.setName("emcc"); // hide emcc path
     if (options.optimize == .Debug) {
         emcc.addArgs(&.{ "-Og", "-sSAFE_HEAP=1", "-sSTACK_OVERFLOW_CHECK=1" });
@@ -430,8 +424,9 @@ pub const EmRunOptions = struct {
     emsdk: *Build.Dependency,
 };
 pub fn emRunStep(b: *Build, options: EmRunOptions) *Build.Step.Run {
-    const emrun_path = emTool(b, options.emsdk, "emrun").getPath(b);
-    const emrun = b.addSystemCommand(&.{ emrun_path, b.fmt("{s}/web/{s}.html", .{ b.install_path, options.name }) });
+    const emrun_path = emTool(b, options.emsdk, "emrun");
+    const emrun = b.addRunFile(emrun_path);
+    emrun.addArgs(&.{b.fmt("web/{s}.html", .{options.name})});
     return emrun;
 }
 
@@ -444,8 +439,8 @@ pub const EmBuilderOptions = struct {
     emsdk: *Build.Dependency,
 };
 pub fn emBuilderStep(b: *Build, options: EmBuilderOptions) *Build.Step.Run {
-    const embuilder_path = emTool(b, options.emsdk, "embuilder").getPath(b);
-    const embuilder = b.addSystemCommand(&.{embuilder_path});
+    const embuilder_path = emTool(b, options.emsdk, "embuilder");
+    const embuilder = b.addRunFile(embuilder_path);
     if (options.lto) {
         embuilder.addArg("--lto");
     }
@@ -471,16 +466,12 @@ pub fn emTool(b: *Build, emsdk: *Build.Dependency, tool: []const u8) Build.LazyP
 
 fn createEmsdkStep(b: *Build, emsdk: *Build.Dependency) *Build.Step.Run {
     if (builtin.os.tag == .windows) {
-        return b.addSystemCommand(&.{emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}).getPath(b)});
+        return b.addAddRun(emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
     } else {
         const step = b.addSystemCommand(&.{"bash"});
-        step.addArg(emSdkLazyPath(b, emsdk, &.{"emsdk"}).getPath(b));
+        step.addFileArg(emSdkLazyPath(b, emsdk, &.{"emsdk"}));
         return step;
     }
-}
-
-fn fileExists(b: *Build, path: []const u8) !bool {
-    return !std.meta.isError(std.Io.Dir.cwd().access(b.graph.io, path, .{}));
 }
 
 // One-time setup of the Emscripten SDK (runs 'emsdk install + activate'). If the
@@ -494,19 +485,13 @@ fn fileExists(b: *Build, path: []const u8) !bool {
 // NOTE 3: this code works just fine when the SDK version is updated in build.zig.zon
 // since this will be cloned into a new zig cache directory which doesn't have
 // an .emscripten file yet until the one-time setup.
-fn emSdkSetupStep(b: *Build, emsdk: *Build.Dependency) !?*Build.Step.Run {
-    const dot_emsc_path = emSdkLazyPath(b, emsdk, &.{".emscripten"}).getPath(b);
-    const dot_emsc_exists = try fileExists(b, dot_emsc_path);
-    if (!dot_emsc_exists) {
-        const emsdk_install = createEmsdkStep(b, emsdk);
-        emsdk_install.addArgs(&.{ "install", "latest" });
-        const emsdk_activate = createEmsdkStep(b, emsdk);
-        emsdk_activate.addArgs(&.{ "activate", "latest" });
-        emsdk_activate.step.dependOn(&emsdk_install.step);
-        return emsdk_activate;
-    } else {
-        return null;
-    }
+fn emSdkAddInstallStep(b: *Build, emsdk: *Build.Dependency) void {
+    const emsdk_install = createEmsdkStep(b, emsdk);
+    emsdk_install.addArgs(&.{ "install", "latest" });
+    const emsdk_activate = createEmsdkStep(b, emsdk);
+    emsdk_activate.addArgs(&.{ "activate", "latest" });
+    emsdk_activate.step.dependOn(&emsdk_install.step);
+    b.step("install-emsdk", "Install Emscripten SDK in zig-pkg").dependOn(&emsdk_activate.step);
 }
 
 //=== EXAMPLES =========================================================================================================
@@ -545,7 +530,7 @@ fn buildExample(b: *Build, example: Example, examples_step: *Build.Step, options
     });
 
     // optionally build shader
-    const opt_shd_step = try buildExampleShader(b, example);
+    const opt_shd_step = null; // try buildExampleShader(b, example);
 
     var run: *Build.Step.Run = undefined;
     if (!isPlatform(options.target.result, .web)) {
@@ -592,25 +577,25 @@ fn buildExample(b: *Build, example: Example, examples_step: *Build.Step, options
     b.step(b.fmt("run-{s}", .{example.name}), b.fmt("Run {s}", .{example.name})).dependOn(&run.step);
 }
 
-fn buildExampleShader(b: *Build, example: Example) !?*Build.Step {
-    if (!example.has_shader) {
-        return null;
-    }
-    const shaders_dir = "examples/shaders/";
-    return shdc.createSourceFile(b, .{
-        .shdc_dep = b.dependency("shdc", .{}),
-        .input = b.fmt("{s}{s}.glsl", .{ shaders_dir, example.name }),
-        .output = b.fmt("{s}{s}.glsl.zig", .{ shaders_dir, example.name }),
-        .slang = .{
-            .glsl430 = example.needs_compute,
-            .glsl410 = !example.needs_compute,
-            .glsl310es = example.needs_compute,
-            .glsl300es = !example.needs_compute,
-            .metal_macos = true,
-            .hlsl5 = true,
-            .wgsl = true,
-            .spirv_vk = true,
-        },
-        .reflection = true,
-    });
-}
+//fn buildExampleShader(b: *Build, example: Example) !?*Build.Step {
+//    if (!example.has_shader) {
+//        return null;
+//    }
+//    const shaders_dir = "examples/shaders/";
+//    return shdc.createSourceFile(b, .{
+//        .shdc_dep = b.dependency("shdc", .{}),
+//        .input = b.fmt("{s}{s}.glsl", .{ shaders_dir, example.name }),
+//        .output = b.fmt("{s}{s}.glsl.zig", .{ shaders_dir, example.name }),
+//        .slang = .{
+//            .glsl430 = example.needs_compute,
+//            .glsl410 = !example.needs_compute,
+//            .glsl310es = example.needs_compute,
+//            .glsl300es = !example.needs_compute,
+//            .metal_macos = true,
+//            .hlsl5 = true,
+//            .wgsl = true,
+//            .spirv_vk = true,
+//        },
+//        .reflection = true,
+//    });
+//}

--- a/build.zig
+++ b/build.zig
@@ -466,7 +466,7 @@ pub fn emTool(b: *Build, emsdk: *Build.Dependency, tool: []const u8) Build.LazyP
 
 fn createEmsdkStep(b: *Build, emsdk: *Build.Dependency) *Build.Step.Run {
     if (builtin.os.tag == .windows) {
-        return b.addAddRun(emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
+        return b.addAddRunFile(emSdkLazyPath(b, emsdk, &.{"emsdk.bat"}));
     } else {
         const step = b.addSystemCommand(&.{"bash"});
         step.addFileArg(emSdkLazyPath(b, emsdk, &.{"emsdk"}));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "N-V-__8AAMXHCQBSMMTsbLPKGw_6MjsNwQIJWmtoc1fzEuAz",
         },
         .shdc = .{
-            .url = "git+https://github.com/floooh/sokol-tools-bin?ref=zig-get-path-removal#6a5fb09167b8df258cba8e0255dfc44610dff67f",
-            .hash = "sokolshdc-0.1.0-r2KZDkWDSgM0eowALXQBIULc4pPMVywzPcA1NdQK7tqq",
+            .url = "git+https://github.com/floooh/sokol-tools-bin?ref=zig-get-path-removal#c4b2c616414dd9fb2b8435c310a142c1c99c0fe0",
+            .hash = "sokolshdc-0.1.0-r2KZDkeESgMHzbYGbT3eaXMqV-6K6DxDvej22dS9kaYU",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,7 +13,7 @@
             .hash = "N-V-__8AAMXHCQBSMMTsbLPKGw_6MjsNwQIJWmtoc1fzEuAz",
         },
         .shdc = .{
-            .url = "git+https://github.com/floooh/sokol-tools-bin?ref=zig-get-path-removal#c4b2c616414dd9fb2b8435c310a142c1c99c0fe0",
+            .url = "git+https://github.com/floooh/sokol-tools-bin#de951298f055d82a96140c04c7462a0fed028745",
             .hash = "sokolshdc-0.1.0-r2KZDkeESgMHzbYGbT3eaXMqV-6K6DxDvej22dS9kaYU",
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,9 +12,9 @@
             .url = "git+https://github.com/emscripten-core/emsdk?ref=5.0.6#948c31acd3f369a5da276e33ab2ed57108c165e5",
             .hash = "N-V-__8AAMXHCQBSMMTsbLPKGw_6MjsNwQIJWmtoc1fzEuAz",
         },
-        //.shdc = .{
-        //    .url = "git+https://github.com/floooh/sokol-tools-bin#1a9a4e54090fec42c5d13169b638f09f25474953",
-        //    .hash = "sokolshdc-0.1.0-r2KZDjCESgPWh_7sOPQXfzFSPLsAg1MqRfvwnLa4pbWC",
-        //},
+        .shdc = .{
+            .url = "git+https://github.com/floooh/sokol-tools-bin?ref=zig-get-path-removal#6a5fb09167b8df258cba8e0255dfc44610dff67f",
+            .hash = "sokolshdc-0.1.0-r2KZDkWDSgM0eowALXQBIULc4pPMVywzPcA1NdQK7tqq",
+        },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,9 +12,9 @@
             .url = "git+https://github.com/emscripten-core/emsdk?ref=5.0.6#948c31acd3f369a5da276e33ab2ed57108c165e5",
             .hash = "N-V-__8AAMXHCQBSMMTsbLPKGw_6MjsNwQIJWmtoc1fzEuAz",
         },
-        .shdc = .{
-            .url = "git+https://github.com/floooh/sokol-tools-bin#1a9a4e54090fec42c5d13169b638f09f25474953",
-            .hash = "sokolshdc-0.1.0-r2KZDjCESgPWh_7sOPQXfzFSPLsAg1MqRfvwnLa4pbWC",
-        },
+        //.shdc = .{
+        //    .url = "git+https://github.com/floooh/sokol-tools-bin#1a9a4e54090fec42c5d13169b638f09f25474953",
+        //    .hash = "sokolshdc-0.1.0-r2KZDjCESgPWh_7sOPQXfzFSPLsAg1MqRfvwnLa4pbWC",
+        //},
     },
 }


### PR DESCRIPTION
- replace most occurances of `addSystemCommand()` with `addRunFile()` (which directly works with LazyPath)
- make emsdk installation an explicit run-step (e.g. `zig build install-emsdk`
- replace removed `Builder.install_path`

TODO:
- [x] fix Emscripten builds on Windows
- [x] test and fix for zig 0.16.x
- [x] fix sokol-tools-bin dependency