### PR TITLE
Add a way for consumers of sokol-zig to install the Emscripten SDK

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -83,7 +83,8 @@ pub fn build(b: *Build) !void {
     const emsdk = b.dependency("emsdk", .{});
 
     // add install-emsdk run step
-    emSdkAddInstallStep(b, emsdk);
+    const emsdk_install_step = emSdkInstallStep(b, emsdk, .{});
+    b.step("install-emsdk", "Install Emscripten SDK in zig-pkg").dependOn(emsdk_install_step);
 
     // a module for the actual bindings, and a static link library with the C code
     const mod_sokol = b.addModule("sokol", .{ .root_source_file = b.path("src/sokol/sokol.zig") });
@@ -489,19 +490,20 @@ fn createEmsdkStep(b: *Build, emsdk: *Build.Dependency) *Build.Step.Run {
 // as dependency to the sokol library (since this needs the emsdk in place),
 // if the emsdk was already setup, null will be returned.
 // NOTE: ideally this would go into a separate emsdk-zig package
-// NOTE 2: the file exists check is a bit hacky, it would be cleaner
-// to build an on-the-fly helper tool which takes care of the SDK
-// setup and just does nothing if it already happened
-// NOTE 3: this code works just fine when the SDK version is updated in build.zig.zon
+// NOTE 2: this code works just fine when the SDK version is updated in build.zig.zon
 // since this will be cloned into a new zig cache directory which doesn't have
 // an .emscripten file yet until the one-time setup.
-fn emSdkAddInstallStep(b: *Build, emsdk: *Build.Dependency) void {
+pub const EmSdkInstallOptions = struct {
+    version: []const u8 = "latest",
+};
+pub fn emSdkInstallStep(b: *Build, emsdk: *Build.Dependency, options: EmSdkInstallOptions) *Build.Step {
+    const version = options.version;
     const emsdk_install = createEmsdkStep(b, emsdk);
-    emsdk_install.addArgs(&.{ "install", "latest" });
+    emsdk_install.addArgs(&.{ "install", version });
     const emsdk_activate = createEmsdkStep(b, emsdk);
-    emsdk_activate.addArgs(&.{ "activate", "latest" });
+    emsdk_activate.addArgs(&.{ "activate", version });
     emsdk_activate.step.dependOn(&emsdk_install.step);
-    b.step("install-emsdk", "Install Emscripten SDK in zig-pkg").dependOn(&emsdk_activate.step);
+    return &emsdk_activate.step;
 }
 
 //=== EXAMPLES =========================================================================================================


### PR DESCRIPTION
As of the changes in https://github.com/floooh/sokol-zig/pull/156 consumers of the `sokol-zig` library no longer have a direct way of installing the Emscripten SDK from their own `zig build`.

In the mentioned pull request, the install of the SDK is now performed via `zig build install-emsdk` step, and (as far as I'm aware) there is no way for a downstream `build.zig` to perform or depend upon an upstream step.

The changes in this pull request expose the function which creates a `std.Build.Step` to perform the install and activation of the SDK so that downstream projects have a way to perform the install as they see fit.

e.g.

    // build.zig
    const std = @import("std");
    pub fn build(b: *std.Build) void {
        const sokol_dep = b.dependency("sokol", .{});
        const emsdk_dep = sokol_dep.builder.dependency("emsdk", .{});
    
        // Create a step to handle installing the Emscripten SDK
        const emsdk_install_step = @import("sokol").emSdkInstallStep(b, emsdk_dep, .{});

        // We can now expose our for manual install:
        b.step("install-emsdk", "Install Emscripten SDK in zig-pkg").dependOn(emsdk_install_step);
    
        // Or add it as a dependency to the "sokol_clib" artifact so that it is performed automatically
        sokol_dep.artifact("sokol_clib").step.dependOn(emsdk_install_step);
    }

I have further ideas on how to streamline this process further, but it is conditional on a feature such as https://codeberg.org/ziglang/zig/issues/35614 being implemented to Zig, and thus would not be backwards compatible with 0.16.0